### PR TITLE
Have Pipeline#call return the command index

### DIFF
--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -129,9 +129,9 @@ class RedisClientTest < Minitest::Test
 
   def test_pipelining
     result = @redis.pipelined do |pipeline|
-      assert_nil pipeline.call("SET", "foo", "42")
+      assert_equal 0, pipeline.call("SET", "foo", "42")
       assert_equal "OK", @redis.call("SET", "foo", "21") # Not pipelined
-      assert_nil pipeline.call("EXPIRE", "foo", "100")
+      assert_equal 1, pipeline.call("EXPIRE", "foo", "100")
     end
     assert_equal ["OK", 1], result
   end
@@ -172,8 +172,8 @@ class RedisClientTest < Minitest::Test
 
   def test_transaction
     result = @redis.multi do |transaction|
-      transaction.call("SET", "foo", "1")
-      transaction.call("EXPIRE", "foo", "42")
+      assert_equal 0, transaction.call("SET", "foo", "1")
+      assert_equal 1, transaction.call("EXPIRE", "foo", "42")
     end
     assert_equal ["OK", 1], result
   end


### PR DESCRIPTION
This is a cheaper alternative to `redis-rb` futures.

e.g.
```ruby
value_index = nil
results = redis.pipelined do |pipeline|
  pipeline.call("SOMETHING") if something?
  value_index = pipeline.call("GET", "key")
end

results[value_index] # => "MyString"
```

That saves us from allocating a future for every call even though most callers won't use it. `Redis::Future` is also very error prone.

cc @etiennebarrie, opening a PR because I'm a bit on the fence about the practicality of this API.