### PR TITLE
Implement `reconnect_attempts:` config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -171,6 +171,9 @@ Style/GlobalVars:
   Exclude:
     - 'ext/**/*'
 
+Style/ModuleFunction:
+  Enabled: false
+
 Gemspec/RequireMFA:
   Enabled: false
 

--- a/ext/redis_client/hiredis/hiredis_connection.c
+++ b/ext/redis_client/hiredis/hiredis_connection.c
@@ -467,6 +467,12 @@ static VALUE hiredis_init_ssl(VALUE self, VALUE ssl_param) {
     return Qtrue;
 }
 
+static VALUE hiredis_connected_p(VALUE self) {
+    CONNECTION(self, connection);
+
+    return connection->context ? Qtrue : Qfalse;
+}
+
 static VALUE hiredis_write(VALUE self, VALUE command) {
     Check_Type(command, T_ARRAY);
 
@@ -650,6 +656,7 @@ void Init_hiredis_connection(void) {
     rb_define_private_method(rb_cHiredisConnection, "connect_tcp", hiredis_connect_tcp, 2);
     rb_define_private_method(rb_cHiredisConnection, "connect_unix", hiredis_connect_unix, 1);
     rb_define_private_method(rb_cHiredisConnection, "init_ssl", hiredis_init_ssl, 1);
+    rb_define_private_method(rb_cHiredisConnection, "connected?", hiredis_connected_p, 0);
 
     rb_define_private_method(rb_cHiredisConnection, "_write", hiredis_write, 1);
     rb_define_private_method(rb_cHiredisConnection, "_read", hiredis_read, 0);

--- a/lib/redis_client/connection.rb
+++ b/lib/redis_client/connection.rb
@@ -44,12 +44,21 @@ class RedisClient
       raise ConnectionError, error.message
     end
 
+    def connected?
+      !@io.closed?
+    end
+
     def close
       @io.close
     end
 
     def write(command)
-      @io.write(RESP3.dump(command))
+      buffer = RESP3.dump(command)
+      begin
+        @io.write(buffer)
+      rescue SystemCallError, IOError => error
+        raise ConnectionError, error.message
+      end
     end
 
     def write_multi(commands)
@@ -57,7 +66,11 @@ class RedisClient
       commands.each do |command|
         buffer = RESP3.dump(command, buffer)
       end
-      @io.write(buffer)
+      begin
+        @io.write(buffer)
+      rescue SystemCallError, IOError => error
+        raise ConnectionError, error.message
+      end
     end
 
     def read(timeout = nil)
@@ -66,6 +79,8 @@ class RedisClient
       else
         @io.with_timeout(timeout) { RESP3.load(@io) }
       end
+    rescue SystemCallError, IOError => error
+      raise ConnectionError, error.message
     end
   end
 end

--- a/lib/redis_client/hiredis_connection.rb
+++ b/lib/redis_client/hiredis_connection.rb
@@ -55,11 +55,15 @@ class RedisClient
           self.read_timeout = previous_timeout
         end
       end
+    rescue SystemCallError, IOError => error
+      raise ConnectionError, error.message
     end
 
     def write(command)
       _write(command)
       flush
+    rescue SystemCallError, IOError => error
+      raise ConnectionError, error.message
     end
 
     def write_multi(commands)
@@ -67,6 +71,8 @@ class RedisClient
         _write(command)
       end
       flush
+    rescue SystemCallError, IOError => error
+      raise ConnectionError, error.message
     end
   end
 end

--- a/lib/redis_client/middlewares.rb
+++ b/lib/redis_client/middlewares.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class Middleware
+    def initialize
+      @client = nil
+      @config = nil
+    end
+
+    def new(client, config)
+      copy = dup
+      copy.client = client
+      copy.config = config
+      copy
+    end
+
+    protected
+
+    attr_writer :client, :config
+  end
+
+  class ReconnectMiddleware < Middleware
+    def initialize(attempts)
+      super()
+      attempts = Array.new(reconnect_attempts, 0) if attempts.is_a?(Integer)
+      @attempts = attempts
+    end
+
+    def call(command, &block)
+      tries = 0
+      begin
+        @client.call(command, &block)
+      rescue ConnectionError
+        wait_time = @attempts[tries]
+        raise if wait_time.nil?
+
+        sleep(wait_time) if wait_time > 0
+        tries += 1
+        retry
+      end
+    end
+
+    def call_pipelined(commands, &block)
+      tries = 0
+      begin
+        @client.call_pipelined(commands, &block)
+      rescue ConnectionError
+        wait_time = @attempts[tries]
+        raise if wait_time.nil?
+
+        sleep(wait_time) if wait_time > 0
+        tries += 1
+        retry
+      end
+    end
+  end
+end

--- a/test/support/redis_server_helper.rb
+++ b/test/support/redis_server_helper.rb
@@ -28,6 +28,7 @@ module RedisServerHelper
       port: TCP_PORT,
       timeout: 0.1,
       driver: ENV.fetch("DRIVER", "ruby").to_sym,
+      reconnect_attempts: false,
     }
   end
 
@@ -36,6 +37,7 @@ module RedisServerHelper
       host: HOST,
       port: TLS_PORT,
       timeout: 0.1,
+      reconnect_attempts: false,
       ssl: true,
       ssl_params: {
         verify_hostname: false, # TODO: See if we could actually verify the hostname with our CI and dev setup
@@ -51,6 +53,7 @@ module RedisServerHelper
     {
       path: SOCKET_FILE.to_s,
       timeout: 0.1,
+      reconnect_attempts: false,
       driver: ENV.fetch("DRIVER", "ruby").to_sym,
     }
   end


### PR DESCRIPTION
Can be either a simple integer, or a list of sleep durations.

TODO: I need to find a decent way to test this, unfortunately I can't seem to find a toxiproxy toxic that would succeed on retries.
