### PR TITLE
Build tweaks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Layout/LineLength:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
+Layout/LineEndStringConcatenationIndentation:
+  EnforcedStyle: indented
+
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/ext/redis_client/hiredis/extconf.rb
+++ b/ext/redis_client/hiredis/extconf.rb
@@ -25,13 +25,14 @@ if RUBY_ENGINE == "ruby"
     &.split(File::PATH_SEPARATOR)
     &.detect { |dir| dir.include?("openssl") }
 
-  if !openssl_include || !openssl_lib
+  if (!openssl_include || !openssl_lib) && !have_header("openssl/ssl.h")
     raise "OpenSSL library could not be found. You might want to use --with-openssl-dir=<dir> option to specify the " \
       "prefix where OpenSSL is installed."
   end
 
   Dir.chdir(hiredis_dir) do
-    success = system(%(#{make_program} static USE_SSL=1 CFLAGS="-I#{openssl_include}" SSL_LDFLAGS="-L#{openssl_lib}"))
+    flags = %(CFLAGS="-I#{openssl_include}" SSL_LDFLAGS="-L#{openssl_lib}") if openssl_lib
+    success = system("#{make_program} static USE_SSL=1 #{flags}")
     raise "Building hiredis failed" unless success
   end
 

--- a/ext/redis_client/hiredis/extconf.rb
+++ b/ext/redis_client/hiredis/extconf.rb
@@ -17,6 +17,14 @@ if RUBY_ENGINE == "ruby"
 
   openssl_include, openssl_lib = dir_config("openssl")
 
+  openssl_include ||= dir_config("opt").first
+    &.split(File::PATH_SEPARATOR)
+    &.detect { |dir| dir.include?("openssl") }
+
+  openssl_lib ||= dir_config("opt").last
+    &.split(File::PATH_SEPARATOR)
+    &.detect { |dir| dir.include?("openssl") }
+
   if !openssl_include || !openssl_lib
     raise "OpenSSL library could not be found. You might want to use --with-openssl-dir=<dir> option to specify the " \
       "prefix where OpenSSL is installed."

--- a/ext/redis_client/hiredis/extconf.rb
+++ b/ext/redis_client/hiredis/extconf.rb
@@ -15,8 +15,15 @@ if RUBY_ENGINE == "ruby"
     'make'
   end
 
+  openssl_include, openssl_lib = dir_config("openssl")
+
+  if !openssl_include || !openssl_lib
+    raise "OpenSSL library could not be found. You might want to use --with-openssl-dir=<dir> option to specify the " \
+      "prefix where OpenSSL is installed."
+  end
+
   Dir.chdir(hiredis_dir) do
-    success = system("#{make_program} static USE_SSL=1")
+    success = system(%(#{make_program} static USE_SSL=1 CFLAGS="-I#{openssl_include}" SSL_LDFLAGS="-L#{openssl_lib}"))
     raise "Building hiredis failed" unless success
   end
 

--- a/ext/redis_client/hiredis/extconf.rb
+++ b/ext/redis_client/hiredis/extconf.rb
@@ -5,8 +5,8 @@ require "mkmf"
 if RUBY_ENGINE == "ruby"
   hiredis_dir = File.expand_path('vendor', __dir__)
 
-  RbConfig::CONFIG['configure_args'] =~ /with-make-prog=(\w+)/
-  make_program = case RUBY_PLATFORM
+  make_program = with_config("make-prog", ENV["MAKE"])
+  make_program ||= case RUBY_PLATFORM
   when /mswin/
     'nmake'
   when /(bsd|solaris)/


### PR DESCRIPTION
As it is, the extension doesn't compile with Homebrew on arm64 out of the box, because it uses /opt/homebrew as its prefix, and hiredis looks for openssl in /usr/local/opt/openssl:
https://github.com/redis-rb/redis-client/blob/c952298ffe54cce44dcdf861f6a0f633f973bd9e/ext/redis_client/hiredis/vendor/Makefile#L82

You can make maybe install the gem using the OPENSSL_PREFIX env variable:
```sh-session
$ bundle exec rake
$ OPENSSL_PREFIX=$(brew --prefix openssl@1.1) gem install pkg/redis-client-0.0.0.gem
Building native extensions. This could take a while...
Successfully installed redis-client-0.0.0
1 gem installed
```

But actually not always, it depends on the way Ruby was built. It can compile if Ruby was built using `--with-opt-dir`, like [ruby-install does](https://github.com/postmodern/ruby-install/blob/v0.8.3/share/ruby-install/ruby/functions.sh#L31), the [dir config for "opt" gets pulled when mkmf is required](https://github.com/ruby/ruby/blob/v3_1_1/lib/mkmf.rb#L2635), which [searches the --with-opt-dir config](https://github.com/ruby/ruby/blob/v3_1_1/lib/mkmf.rb#L1806), this uses the [internal arg_config](https://github.com/ruby/ruby/blob/v3_1_1/lib/mkmf.rb#L1680), [uses the $configure_args](https://github.com/ruby/ruby/blob/v3_1_1/lib/mkmf.rb#L1659), which [in part](https://github.com/ruby/ruby/blob/v3_1_1/lib/mkmf.rb#L98-L100) come from the [arguments used to build Ruby](https://github.com/ruby/ruby/blob/53f5fc4236a754ddf94b20dbb70ab63bd5109b18/lib/mkmf.rb#L69).

Which means that even on a ruby-build (or otherwise configured Ruby), you can build the gem:

```sh-session
$ OPENSSL_PREFIX=$(brew --prefix openssl@1.1) gem install pkg/redis-client-0.0.0.gem -- --with-opt-dir=$(brew --prefix openssl@1.1) 
```

But that's not a great experience.

---

The first commit uses mkmf `dir_config` to be able to configure OpenSSL with `--with-openssl-dir` (or `--with-openssl-include` and `--with-openssl-lib`):

```sh-session
$ gem install pkg/redis-client-0.0.0.gem -- --with-openssl-dir=$(brew --prefix openssl@1.1)
```

In turn, that makes it compile with no configuration if you used `--with-openssl-dir` to build Ruby.

I ended up not using the `OPENSSL_PREFIX` from hiredis's Makefile but just configuring `CFLAGS` and `SSL_LDFLAGS`

---

The second commit uses the opt dir from `dir_config`, though in that case I had to guess looking for a path including "openssl". It's not that clean but it helps for rubies built using ruby-install, in any case one can still override using `--with-openssl-dir`.

---

Then I tweaked the handling of `make-prog`, it looks like mkmf has `$make` which would be perfect for us but it's not documented.

---

If the header's there, we just try to compile hiredis without changing anything.