### PR TITLE
Fix hiredis test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         os: ["ubuntu-latest"]
         redis: ["6.2"]
         ruby: ["3.1", "3.0", "2.7", "2.6", "2.5"]
-        driver: ["ruby"] #, "hiredis"]
+        driver: ["ruby", "hiredis"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code


### PR DESCRIPTION
It started segfaulting as part of https://github.com/redis-rb/redis-client/pull/11, even though it was unchanged, need to investigate.