### PR TITLE
Implement built-in connection pooling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -185,3 +185,6 @@ Style/ModuleFunction:
 
 Style/CombinableLoops:
   Enabled: false
+
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     redis-client (0.0.0)
+      connection_pool
 
 GEM
   remote: https://rubygems.org/

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -9,11 +9,14 @@ class RedisClient
   Error = Class.new(StandardError)
 
   ConnectionError = Class.new(Error)
+
+  FailoverError = Class.new(ConnectionError)
+
   TimeoutError = Class.new(ConnectionError)
   ReadTimeoutError = Class.new(TimeoutError)
   WriteTimeoutError = Class.new(TimeoutError)
   ConnectTimeoutError = Class.new(TimeoutError)
-  FailoverError = Class.new(ConnectionError)
+  CheckoutTimeoutError = Class.new(ConnectTimeoutError)
 
   class CommandError < Error
     class << self
@@ -69,6 +72,11 @@ class RedisClient
     @raw_connection = nil
     @disable_reconnection = false
   end
+
+  def with(_options = nil)
+    yield self
+  end
+  alias_method :then, :with
 
   def timeout=(timeout)
     @connect_timeout = @read_timeout = @write_timeout = timeout
@@ -423,3 +431,4 @@ class RedisClient
 end
 
 require "redis_client/resp3"
+require "redis_client/pooled"

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -63,6 +63,11 @@ class RedisClient
         false
       end
 
+      def new_pool(**kwargs)
+        kwargs[:timeout] ||= DEFAULT_TIMEOUT
+        Pooled.new(self, **kwargs)
+      end
+
       def new_client(**kwargs)
         RedisClient.new(self, **kwargs)
       end

--- a/lib/redis_client/pooled.rb
+++ b/lib/redis_client/pooled.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "connection_pool"
+
+class RedisClient
+  class Pooled
+    EMPTY_HASH = {}.freeze
+
+    def initialize(config, **kwargs)
+      @config = config
+      @pool_kwargs = kwargs
+      @pool = new_pool
+      @mutex = Mutex.new
+    end
+
+    def with(options = EMPTY_HASH, &block)
+      pool.with(options, &block)
+    rescue ConnectionPool::TimeoutError => error
+      raise CheckoutTimeoutError, "Couldn't checkout a connection in time: #{error.message}"
+    end
+    alias_method :then, :with
+
+    def close
+      if @pool
+        @mutex.synchronize do
+          pool = @pool
+          @pool = nil
+          pool&.shutdown(&:close)
+        end
+      end
+      nil
+    end
+
+    %w(pipelined).each do |method|
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def #{method}(&block)
+          with { |r| r.#{method}(&block) }
+        end
+      RUBY
+    end
+
+    %w(multi).each do |method|
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def #{method}(**kwargs, &block)
+          with { |r| r.#{method}(**kwargs, &block) }
+        end
+      RUBY
+    end
+
+    %w(call call_once blocking_call pubsub).each do |method|
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def #{method}(*args)
+          with { |r| r.#{method}(*args) }
+        end
+      RUBY
+    end
+
+    %w(scan sscan hscan zscan).each do |method|
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def #{method}(*args, &block)
+          unless block_given?
+            return to_enum(__callee__, *args)
+          end
+
+          with { |r| r.#{method}(*args, &block) }
+        end
+      RUBY
+    end
+
+    private
+
+    def pool
+      @pool ||= @mutex.synchronize { new_pool }
+    end
+
+    def new_pool
+      ConnectionPool.new(**@pool_kwargs) { @config.new_client }
+    end
+  end
+end

--- a/redis-client.gemspec
+++ b/redis-client.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/redis_client/hiredis/extconf.rb"]
+
+  spec.add_runtime_dependency "connection_pool"
 end

--- a/test/redis_client/sentinel_test.rb
+++ b/test/redis_client/sentinel_test.rb
@@ -12,11 +12,7 @@ class RedisClient
     end
 
     def teardown
-      unless healthy_master?
-        puts
-        puts "Restarting services"
-        Servers::ALL.reset
-      end
+      Servers::ALL.reset
     end
 
     def test_new_client
@@ -165,18 +161,6 @@ class RedisClient
         driver: ENV.fetch("DRIVER", "ruby").to_sym,
         **kwargs,
       )
-    end
-
-    def healthy_master?
-      Servers::SENTINELS.each do |sentinel|
-        sentinel_client = RedisClient.new(host: sentinel.host, port: sentinel.port)
-        return false unless sentinel_client.call("SENTINEL", "get-master-addr-by-name", "cache") == [Servers::REDIS.host, Servers::REDIS.port.to_s]
-      end
-
-      client = RedisClient.new(host: Servers::REDIS.host, port: Servers::REDIS.port)
-      return false unless client.call("ROLE")&.first == "master"
-
-      true
     end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/4

I think this would simplify usage a lot in most cases, so it's probably worth having it built-in.