### PR TITLE
Fix conflict when both hiredis-rb and redis-client are loaded

### DIFF
--- a/ext/redis_client/hiredis/export.clang
+++ b/ext/redis_client/hiredis/export.clang
@@ -1,0 +1,2 @@
+_Init_hiredis_connection
+_ruby_abi_version

--- a/ext/redis_client/hiredis/export.gcc
+++ b/ext/redis_client/hiredis/export.gcc
@@ -1,0 +1,7 @@
+hiredis_connection_1.0 { 
+  global: 
+    Init_hiredis_connection;
+    ruby_abi_version;
+  local: 
+    *;
+};

--- a/ext/redis_client/hiredis/extconf.rb
+++ b/ext/redis_client/hiredis/extconf.rb
@@ -39,9 +39,17 @@ if RUBY_ENGINE == "ruby"
   end
 
   $CFLAGS << " -I#{hiredis_dir}"
-  $LDFLAGS << " #{hiredis_dir}/libhiredis.a #{hiredis_dir}/libhiredis_ssl.a -lssl -lcrypto"
+  $LDFLAGS << " -lssl -lcrypto"
+  $libs << " #{hiredis_dir}/libhiredis.a #{hiredis_dir}/libhiredis_ssl.a "
   $CFLAGS << " -O3"
   $CFLAGS << " -std=c99 "
+
+  case RbConfig::CONFIG['CC']
+  when /gcc/i
+    $LDFLAGS << ' -Wl,--version-script="' << File.join(__dir__, 'export.gcc') << '"'
+  when /clang/i
+    $LDFLAGS << ' -Wl,-exported_symbols_list,"' << File.join(__dir__, 'export.clang') << '"'
+  end
 
   if ENV["EXT_PEDANTIC"]
     $CFLAGS << " -Werror"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,3 +14,12 @@ require "minitest/autorun"
 unless ENV["REDIS_CLIENT_RESTART_SERVER"] == "0"
   Minitest.after_run { Servers::ALL.shutdown }
 end
+
+if ENV["DRIVER"] == "hiredis"
+  # See: https://github.com/redis-rb/redis-client/issues/16
+  # The hiredis-rb gems expose all hiredis symbols, so we must be careful
+  # about how we link against it.
+  require "redis"
+  require "hiredis"
+  Redis.new(host: Servers::HOST, port: Servers::REDIS_TCP_PORT, driver: :hiredis).ping
+end


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/16

Using `$libs` instead of `$LDFLAGS` wasn't enough, because the symbols were still exported. So I went farther and took inspiration from what `grpc` does to only export the required symbols: https://github.com/grpc/grpc/blob/1cd6e69347cbf62a012477fe184ee6fa8f25d32c/src/ruby/ext/grpc/extconf.rb#L87-L89

cc @flavorjones