### PR TITLE
Treat call keyword arguments as Redis flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Treat `#call` keyword arguments as Redis flags.
 - Fix `RedisClient#multi` returning some errors as values instead of raising them.
 
 # 0.2.1

--- a/benchmark/pipelined_hiredis.md
+++ b/benchmark/pipelined_hiredis.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.0 sha=00000000:0 malloc=libc bits=64 build=fa9
 ### small string
 
 ```
-            redis-rb:     5216.4 i/s
-        redis-client:     6947.1 i/s - 1.33x  (± 0.00) faster
+            redis-rb:     5470.5 i/s
+        redis-client:     6913.0 i/s - 1.26x  (± 0.00) faster
 
 ```
 
 ### large string
 
 ```
-            redis-rb:      364.3 i/s
-        redis-client:      409.8 i/s - 1.12x  (± 0.00) faster
+            redis-rb:      382.6 i/s
+        redis-client:      437.7 i/s - 1.14x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:     2571.4 i/s
-        redis-client:     3797.1 i/s - 1.48x  (± 0.00) faster
+            redis-rb:     2599.9 i/s
+        redis-client:     3430.7 i/s - 1.32x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:       83.0 i/s
-        redis-client:      121.3 i/s - 1.46x  (± 0.00) faster
+            redis-rb:       80.2 i/s
+        redis-client:      108.6 i/s - 1.36x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:     2407.0 i/s
-        redis-client:     4375.8 i/s - 1.82x  (± 0.00) faster
+            redis-rb:     2412.7 i/s
+        redis-client:     4143.8 i/s - 1.72x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:       48.6 i/s
-        redis-client:       80.6 i/s - 1.66x  (± 0.00) faster
+            redis-rb:       48.0 i/s
+        redis-client:       79.4 i/s - 1.65x  (± 0.00) faster
 
 ```
 

--- a/benchmark/pipelined_ruby.md
+++ b/benchmark/pipelined_ruby.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.0 sha=00000000:0 malloc=libc bits=64 build=fa9
 ### small string
 
 ```
-            redis-rb:     1019.3 i/s
-        redis-client:     2605.2 i/s - 2.56x  (± 0.00) faster
+            redis-rb:     1237.2 i/s
+        redis-client:     2709.8 i/s - 2.19x  (± 0.00) faster
 
 ```
 
 ### large string
 
 ```
-            redis-rb:      262.7 i/s
-        redis-client:      335.7 i/s - 1.28x  (± 0.00) faster
+            redis-rb:      276.2 i/s
+        redis-client:      356.4 i/s - 1.29x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:      442.6 i/s
-        redis-client:     1114.1 i/s - 2.52x  (± 0.00) faster
+            redis-rb:      445.4 i/s
+        redis-client:     1103.9 i/s - 2.48x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:        2.8 i/s
-        redis-client:       14.4 i/s - 5.24x  (± 0.00) faster
+            redis-rb:        2.7 i/s
+        redis-client:       14.2 i/s - 5.26x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:      377.3 i/s
-        redis-client:     1033.6 i/s - 2.74x  (± 0.00) faster
+            redis-rb:      374.0 i/s
+        redis-client:     1043.9 i/s - 2.79x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:        2.6 i/s
-        redis-client:       13.1 i/s - 4.98x  (± 0.00) faster
+            redis-rb:        2.7 i/s
+        redis-client:       13.1 i/s - 4.76x  (± 0.00) faster
 
 ```
 

--- a/benchmark/pipelined_yjit.md
+++ b/benchmark/pipelined_yjit.md
@@ -6,40 +6,40 @@ redis-server: `Redis server v=7.0.0 sha=00000000:0 malloc=libc bits=64 build=fa9
 ### small string
 
 ```
-            redis-rb:     1249.9 i/s
-        redis-client:     2726.2 i/s - 2.18x  (± 0.00) faster
+            redis-rb:     1269.1 i/s
+        redis-client:     2735.9 i/s - 2.16x  (± 0.00) faster
 
 ```
 
 ### large string
 
 ```
-            redis-rb:      270.0 i/s
-        redis-client:      346.1 i/s - 1.28x  (± 0.00) faster
+            redis-rb:      280.1 i/s
+        redis-client:      356.2 i/s - 1.27x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:      448.1 i/s
-        redis-client:     1119.5 i/s - 2.50x  (± 0.00) faster
+            redis-rb:      446.3 i/s
+        redis-client:     1109.2 i/s - 2.49x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:        2.7 i/s
-        redis-client:       14.2 i/s - 5.25x  (± 0.00) faster
+            redis-rb:        2.8 i/s
+        redis-client:       14.3 i/s - 5.14x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:      375.4 i/s
-        redis-client:     1043.9 i/s - 2.78x  (± 0.00) faster
+            redis-rb:      375.5 i/s
+        redis-client:     1042.1 i/s - 2.77x  (± 0.00) faster
 
 ```
 
@@ -47,7 +47,7 @@ redis-server: `Redis server v=7.0.0 sha=00000000:0 malloc=libc bits=64 build=fa9
 
 ```
             redis-rb:        2.6 i/s
-        redis-client:       13.1 i/s - 5.01x  (± 0.00) faster
+        redis-client:       13.1 i/s - 4.99x  (± 0.00) faster
 
 ```
 

--- a/benchmark/single_hiredis.md
+++ b/benchmark/single_hiredis.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.0 sha=00000000:0 malloc=libc bits=64 build=fa9
 ### small string
 
 ```
-            redis-rb:    41844.9 i/s
-        redis-client:    42348.2 i/s - same-ish: difference falls within error
+            redis-rb:    41490.9 i/s
+        redis-client:    42519.9 i/s - same-ish: difference falls within error
 
 ```
 
 ### large string
 
 ```
-            redis-rb:    20775.2 i/s
-        redis-client:    18482.8 i/s - 1.12x  (± 0.00) slower
+            redis-rb:    20882.7 i/s
+        redis-client:    18877.0 i/s - 1.11x  (± 0.00) slower
 
 ```
 
 ### small list
 
 ```
-            redis-rb:    39427.9 i/s
-        redis-client:    39829.7 i/s - same-ish: difference falls within error
+            redis-rb:    38592.2 i/s
+        redis-client:    38920.2 i/s - same-ish: difference falls within error
 
 ```
 
 ### large list
 
 ```
-            redis-rb:     7525.2 i/s
-        redis-client:     9523.5 i/s - 1.27x  (± 0.00) faster
+            redis-rb:     7562.3 i/s
+        redis-client:     8834.8 i/s - 1.17x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:    37035.3 i/s
-        redis-client:    40639.2 i/s - 1.10x  (± 0.00) faster
+            redis-rb:    37152.5 i/s
+        redis-client:    39277.5 i/s - 1.06x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:     4270.2 i/s
-        redis-client:     6005.2 i/s - 1.41x  (± 0.00) faster
+            redis-rb:     4762.2 i/s
+        redis-client:     6379.1 i/s - 1.34x  (± 0.00) faster
 
 ```
 

--- a/benchmark/single_ruby.md
+++ b/benchmark/single_ruby.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.0 sha=00000000:0 malloc=libc bits=64 build=fa9
 ### small string
 
 ```
-            redis-rb:    30673.8 i/s
-        redis-client:    31609.3 i/s - same-ish: difference falls within error
+            redis-rb:    30613.5 i/s
+        redis-client:    31272.9 i/s - same-ish: difference falls within error
 
 ```
 
 ### large string
 
 ```
-            redis-rb:    17829.2 i/s
-        redis-client:    19749.7 i/s - 1.11x  (± 0.00) faster
+            redis-rb:    17719.1 i/s
+        redis-client:    19680.8 i/s - 1.11x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:    24225.5 i/s
-        redis-client:    27195.9 i/s - 1.12x  (± 0.00) faster
+            redis-rb:    24238.9 i/s
+        redis-client:    26521.1 i/s - 1.09x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:      408.8 i/s
-        redis-client:     1261.0 i/s - 3.08x  (± 0.00) faster
+            redis-rb:      403.1 i/s
+        redis-client:     1251.7 i/s - 3.11x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:    21874.1 i/s
-        redis-client:    26334.4 i/s - 1.20x  (± 0.00) faster
+            redis-rb:    21916.6 i/s
+        redis-client:    26036.2 i/s - 1.19x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:      384.0 i/s
-        redis-client:     1198.4 i/s - 3.12x  (± 0.00) faster
+            redis-rb:      384.3 i/s
+        redis-client:     1197.3 i/s - 3.12x  (± 0.00) faster
 
 ```
 

--- a/benchmark/single_yjit.md
+++ b/benchmark/single_yjit.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.0 sha=00000000:0 malloc=libc bits=64 build=fa9
 ### small string
 
 ```
-            redis-rb:    30872.2 i/s
-        redis-client:    31760.5 i/s - 1.03x  (± 0.00) faster
+            redis-rb:    30820.3 i/s
+        redis-client:    31049.6 i/s - same-ish: difference falls within error
 
 ```
 
 ### large string
 
 ```
-            redis-rb:    17664.3 i/s
-        redis-client:    19755.0 i/s - 1.12x  (± 0.00) faster
+            redis-rb:    17820.8 i/s
+        redis-client:    19549.8 i/s - 1.10x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:    24246.2 i/s
-        redis-client:    27175.6 i/s - 1.12x  (± 0.00) faster
+            redis-rb:    24136.1 i/s
+        redis-client:    27098.1 i/s - 1.12x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:      402.8 i/s
-        redis-client:     1263.5 i/s - 3.14x  (± 0.00) faster
+            redis-rb:      404.5 i/s
+        redis-client:     1264.3 i/s - 3.13x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:    21940.3 i/s
-        redis-client:    26352.3 i/s - 1.20x  (± 0.00) faster
+            redis-rb:    21827.5 i/s
+        redis-client:    26258.3 i/s - 1.20x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:      378.7 i/s
-        redis-client:     1200.7 i/s - 3.17x  (± 0.00) faster
+            redis-rb:      381.1 i/s
+        redis-client:     1202.0 i/s - 3.15x  (± 0.00) faster
 
 ```
 

--- a/lib/redis_client/command_builder.rb
+++ b/lib/redis_client/command_builder.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+class RedisClient
+  module CommandBuilder
+    extend self
+
+    if Symbol.method_defined?(:name)
+      def generate!(args, kwargs)
+        command = args.flat_map do |element|
+          case element
+          when Hash
+            element.flatten
+          when Set
+            element.to_a
+          else
+            element
+          end
+        end
+
+        kwargs.each do |key, value|
+          if value
+            if value == true
+              command << key.name
+            else
+              command << key.name << value
+            end
+          end
+        end
+
+        command.map! do |element|
+          case element
+          when String
+            element
+          when Symbol
+            element.name
+          when Integer, Float
+            element.to_s
+          else
+            raise TypeError, "Unsupported command argument type: #{element.class}"
+          end
+        end
+
+        command
+      end
+    else
+      def generate!(args, kwargs)
+        command = args.flat_map do |element|
+          case element
+          when Hash
+            element.flatten
+          when Set
+            element.to_a
+          else
+            element
+          end
+        end
+
+        kwargs.each do |key, value|
+          if value
+            if value == true
+              command << key.to_s
+            else
+              command << key.to_s << value
+            end
+          end
+        end
+
+        command.map! do |element|
+          case element
+          when String
+            element
+          when Integer, Float, Symbol
+            element.to_s
+          else
+            raise TypeError, "Unsupported command argument type: #{element.class}"
+          end
+        end
+
+        command
+      end
+    end
+  end
+end

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -11,7 +11,7 @@ class RedisClient
     DEFAULT_DB = 0
 
     module Common
-      attr_reader :db, :username, :password, :id, :ssl, :ssl_params,
+      attr_reader :db, :username, :password, :id, :ssl, :ssl_params, :command_builder,
         :connect_timeout, :read_timeout, :write_timeout, :driver, :connection_prelude
 
       alias_method :ssl?, :ssl
@@ -28,6 +28,7 @@ class RedisClient
         ssl: nil,
         ssl_params: nil,
         driver: :ruby,
+        command_builder: CommandBuilder,
         reconnect_attempts: false
       )
         @username = username || DEFAULT_USERNAME
@@ -52,6 +53,8 @@ class RedisClient
         else
           raise ArgumentError, "Unknown driver #{driver.inspect}, expected one of: `:ruby`, `:hiredis`"
         end
+
+        @command_builder = command_builder
 
         reconnect_attempts = Array.new(reconnect_attempts, 0).freeze if reconnect_attempts.is_a?(Integer)
         @reconnect_attempts = reconnect_attempts

--- a/lib/redis_client/resp3.rb
+++ b/lib/redis_client/resp3.rb
@@ -58,32 +58,6 @@ class RedisClient
       String.new(encoding: Encoding::BINARY, capacity: 128)
     end
 
-    def coerce_command!(command)
-      command = command.flat_map do |element|
-        case element
-        when Hash
-          element.flatten
-        when Set
-          element.to_a
-        else
-          element
-        end
-      end
-
-      command.map! do |element|
-        case element
-        when String
-          element
-        when Integer, Float, Symbol
-          element.to_s
-        else
-          raise TypeError, "Unsupported command argument type: #{element.class}"
-        end
-      end
-
-      command
-    end
-
     def dump_any(object, buffer)
       method = DUMP_TYPES.fetch(object.class) do
         raise TypeError, "Unsupported command argument type: #{object.class}"

--- a/test/redis_client/command_builder_test.rb
+++ b/test/redis_client/command_builder_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RedisClient
+  class CommandBuilderTest < Minitest::Test
+    def test_positional
+      assert_equal ["a", "b", "c"], call("a", "b", "c")
+    end
+
+    def test_array
+      assert_equal ["a", "b", "c"], call("a", ["b", "c"])
+    end
+
+    def test_set
+      assert_equal ["a", "b", "c"], call("a", Set["b", "c"])
+    end
+
+    def test_hash
+      assert_equal ["a", "b", "c"], call("a", { "b" => "c" })
+    end
+
+    def test_symbol
+      assert_equal ["a", "b", "c", "d"], call(:a, [:b], { c: :d })
+    end
+
+    def test_numeric
+      assert_equal ["1", "2.3"], call(1, 2.3)
+    end
+
+    def test_kwargs_boolean
+      assert_equal ["withscores"], call(ttl: nil, ex: false, withscores: true)
+    end
+
+    def test_kwargs_values
+      assert_equal ["ttl", "42"], call(ttl: 42)
+    end
+
+    private
+
+    def call(*args, **kwargs)
+      CommandBuilder.generate!(args, kwargs)
+    end
+  end
+end


### PR DESCRIPTION
Following the discussion and experience gathered in https://github.com/mperham/sidekiq/pull/5298, I think that if we handled keyword arguments as Redis flags, we could significantly ease the transition.

e.g.

```ruby
redis_rb.set("key", "value", ex: 42, nx: true)
```

Could be done as:

```ruby
redis_client.call("SET", "key", "value", ex: 42, nx: true)
```

Instead of:
```
redis_client.call("SET", "key", "value", "EX", 42, "nx")
```

With such feature, a simple `method_missing` based delegator could achieve a fairly large compatibility with the `redis` gem.

```ruby
class CompatClient
  def initialize(client)
    @client = client
  end

  private

  def method_missing(...)
    @client.call(...)
  end
end

redis = CompatClient.new(RedisClient.new)
redis.set("key", "value", ex: 42, nx: true) # => "OK"
``` 

### Footguns

The one thing that worries me is the Ruby 2 vs Ruby 3 keyword argument semantic.

```ruby
def call(*args, **kwargs)
  p [args, kwargs]
end

# Ruby 2
call("hash", "foo" => "bar") # => [["hash", {"foo"=>"bar"}], {}]
# Ruby 3
call("hash", "foo" => "bar") # => [["hash"], {"foo"=>"bar"}]
call("hash", { "foo" => "bar" }) # => [["hash", {"foo"=>"bar"}], {}]
```

But that's limited to string hash literals, so likely only used for `HMSET`, I think a warning in the readme might be enough.

cc @etiennebarrie 

Also cc @mperham as I'd love your thoughts on wether you think it would make `redis-client` more usable for you.