### PR TITLE
Add `CommandError#command` to expose the command that caused the error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `CommandError#command` to expose the command that caused the error.
+
 # 0.4.0
 
 - The `hiredis` driver have been moved to the `hiredis-client` gem.

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -89,12 +89,18 @@ class RedisClient
   CheckoutTimeoutError = Class.new(ConnectTimeoutError)
 
   class CommandError < Error
+    attr_reader :command
+
     class << self
       def parse(error_message)
         code = error_message.split(' ', 2).first
         klass = ERRORS.fetch(code, self)
         klass.new(error_message)
       end
+    end
+
+    def _set_command(command)
+      @command = command
     end
   end
 
@@ -405,8 +411,9 @@ class RedisClient
 
     def _coerce!(results)
       if results
-        results.each do |result|
+        results.each_with_index do |result, index|
           if result.is_a?(CommandError)
+            result._set_command(@commands[index + 1])
             raise result
           end
         end

--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -6,6 +6,7 @@ class RedisClient
       write(command)
       result = read(timeout)
       if result.is_a?(CommandError)
+        result._set_command(command)
         raise result
       else
         result
@@ -23,6 +24,7 @@ class RedisClient
         timeout = timeouts && timeouts[index]
         result = read(timeout)
         if result.is_a?(CommandError)
+          result._set_command(commands[index])
           exception ||= result
         end
         results[index] = result

--- a/test/shared/redis_client_tests.rb
+++ b/test/shared/redis_client_tests.rb
@@ -192,23 +192,27 @@ module RedisClientTests
   end
 
   def test_pipelining_error
-    assert_raises RedisClient::CommandError do
+    error = assert_raises RedisClient::CommandError do
       @redis.pipelined do |pipeline|
-        pipeline.call("DOESNOTEXIST")
+        pipeline.call("DOESNOTEXIST", 12)
         pipeline.call("SET", "foo", "42")
       end
     end
+
+    assert_equal ["DOESNOTEXIST", "12"], error.command
 
     assert_equal "42", @redis.call("GET", "foo")
   end
 
   def test_multi_error
-    assert_raises RedisClient::CommandError do
+    error = assert_raises RedisClient::CommandError do
       @redis.multi do |pipeline|
-        pipeline.call("DOESNOTEXIST")
+        pipeline.call("DOESNOTEXIST", 12)
         pipeline.call("SET", "foo", "42")
       end
     end
+
+    assert_equal ["DOESNOTEXIST", "12"], error.command
 
     assert_nil @redis.call("GET", "foo")
   end
@@ -219,6 +223,7 @@ module RedisClientTests
     error = assert_raises RedisClient::CommandError do
       @redis.call("SISMEMBER", "str", "member")
     end
+    assert_equal ["SISMEMBER", "str", "member"], error.command
     assert_includes error.message, "WRONGTYPE Operation against a key holding the wrong kind of value"
 
     error = assert_raises RedisClient::CommandError do


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/20

I'm ok with the implementation complexity, it doesn't seem too bad to maintain, it's just a bit unfortunate to have 3 places to do it.

cc @mperham: if that implementation answer your need, I don't mind adding it.