### PR TITLE
Stop casting RESP3 sets to actual Ruby sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Stop parsing RESP3 sets as Ruby Set instances.
 - Fix `SystemStackError` when parsing very large hashes. Fix: #30
 
 # 0.5.1

--- a/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
+++ b/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
@@ -45,7 +45,7 @@ static inline VALUE rb_hash_new_capa(long capa)
 }
 #endif
 
-static VALUE rb_cSet, rb_eRedisClientCommandError, rb_eRedisClientConnectionError;
+static VALUE rb_eRedisClientCommandError, rb_eRedisClientConnectionError;
 static VALUE rb_eRedisClientConnectTimeoutError, rb_eRedisClientReadTimeoutError, rb_eRedisClientWriteTimeoutError;
 static ID id_parse, id_add, id_new;
 
@@ -176,13 +176,11 @@ static void *reply_create_array(const redisReadTask *task, size_t elements) {
     switch (task->type) {
         case REDIS_REPLY_PUSH:
         case REDIS_REPLY_ARRAY:
+        case REDIS_REPLY_SET:
             value = rb_ary_new_capa(elements);
             break;
         case REDIS_REPLY_MAP:
             value = rb_hash_new_capa(elements / 2);
-            break;
-        case REDIS_REPLY_SET:
-            value = rb_funcallv(rb_cSet, id_new, 0, NULL);
             break;
         default:
             rb_bug("[hiredis] Unexpected create array type %d", task->parent->type);
@@ -670,9 +668,6 @@ void Init_hiredis_connection(void) {
     id_parse = rb_intern("parse");
     id_add = rb_intern("add");
     id_new = rb_intern("new");
-
-    rb_cSet = rb_const_get(rb_cObject, rb_intern("Set"));
-    rb_global_variable(&rb_cSet);
 
     VALUE rb_cRedisClient = rb_const_get(rb_cObject, rb_intern("RedisClient"));
 

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 require "redis_client/version"
 require "redis_client/command_builder"
 require "redis_client/config"

--- a/lib/redis_client/command_builder.rb
+++ b/lib/redis_client/command_builder.rb
@@ -10,8 +10,6 @@ class RedisClient
           case element
           when Hash
             element.flatten
-          when Set
-            element.to_a
           else
             element
           end
@@ -52,8 +50,6 @@ class RedisClient
           case element
           when Hash
             element.flatten
-          when Set
-            element.to_a
           else
             element
           end

--- a/lib/redis_client/ruby_connection/resp3.rb
+++ b/lib/redis_client/ruby_connection/resp3.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "set"
-
 class RedisClient
   module RESP3
     module_function
@@ -41,8 +39,6 @@ class RedisClient
         case element
         when Hash
           element.flatten
-        when Set
-          element.to_a
         else
           element
         end
@@ -144,7 +140,7 @@ class RedisClient
     end
 
     def parse_set(io)
-      parse_sequence(io, parse_integer(io)).to_set
+      parse_sequence(io, parse_integer(io))
     end
 
     def parse_map(io)

--- a/test/redis_client/command_builder_test.rb
+++ b/test/redis_client/command_builder_test.rb
@@ -12,10 +12,6 @@ class RedisClient
       assert_equal ["a", "b", "c"], call("a", ["b", "c"])
     end
 
-    def test_set
-      assert_equal ["a", "b", "c"], call("a", Set["b", "c"])
-    end
-
     def test_hash
       assert_equal ["a", "b", "c"], call("a", { "b" => "c" })
     end

--- a/test/redis_client/resp3_test.rb
+++ b/test/redis_client/resp3_test.rb
@@ -58,10 +58,6 @@ class RedisClient
       assert_dumps ["PRINT", [1, 2, 3]], "*4\r\n$5\r\nPRINT\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n"
     end
 
-    def test_dump_set
-      assert_dumps ["PRINT", Set[1, 2, 3]], "*4\r\n$5\r\nPRINT\r\n$1\r\n1\r\n$1\r\n2\r\n$1\r\n3\r\n"
-    end
-
     def test_dump_hash
       assert_dumps(["PRINT", { 'first' => 1, 'second' => 2 }], "*5\r\n$5\r\nPRINT\r\n$5\r\nfirst\r\n$1\r\n1\r\n$6\r\nsecond\r\n$1\r\n2\r\n")
     end
@@ -105,7 +101,7 @@ class RedisClient
     end
 
     def test_load_set
-      assert_parses Set['orange', 'apple', true, 100, 999], "~5\r\n+orange\r\n+apple\r\n#t\r\n:100\r\n:999\r\n"
+      assert_parses ['orange', 'apple', true, 100, 999], "~5\r\n+orange\r\n+apple\r\n#t\r\n:100\r\n:999\r\n"
     end
 
     def test_load_map


### PR DESCRIPTION
At first it made sense because the protocol clearly mark them as
sets, but:

 - The Ruby Set class is way more expensive than an array.
 - It would make migration from `redis-rb` harder.
 - It's trivial to cast to set if needed, this isn't making anyone's
   life easier.

