### PR TITLE
Test against Redis 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,38 @@ jobs:
           EXT_PEDANTIC: "1"
           REDIS: ${{ matrix.redis }}
 
+  redis:
+    name: Redis ${{ matrix.redis }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        redis: ["7.0"]
+        ruby: ["3.1"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Cache redis build
+        uses: actions/cache@v1
+        with:
+          path: tmp/cache
+          key: "local-tmp-cache-${{ matrix.redis }}-on-${{ matrix.os }}"
+      - name: Lower system timeout
+        run: sudo sysctl -w net.ipv4.tcp_syn_retries=2
+      - name: Test
+        run: |
+          bundle exec rake ci
+        env:
+          EXT_PEDANTIC: "1"
+          REDIS: ${{ matrix.redis }}
+
   # Redis sentinel is super slow to setup nad very flaky
   # So we run them independently against a single set of versions
   # so that they're easier to retry and less likely to flake.

--- a/test/shared/redis_client_tests.rb
+++ b/test/shared/redis_client_tests.rb
@@ -86,7 +86,7 @@ module RedisClientTests
 
   def test_argument_casting_arrays
     assert_equal 3, @redis.call("LPUSH", "list", [1, 2, 3])
-    assert_equal ["1", "2", "3"], @redis.call("RPOP", "list", 3)
+    assert_equal ["3", "2", "1"], @redis.call("LRANGE", "list", 0, 3)
 
     error = assert_raises TypeError do
       @redis.call("LPUSH", "list", [1, [2, 3]])
@@ -134,7 +134,7 @@ module RedisClientTests
 
   def test_pipeline_argument_casting_arrays
     assert_equal([3], @redis.pipelined { |p| p.call("LPUSH", "list", [1, 2, 3]) })
-    assert_equal ["1", "2", "3"], @redis.call("RPOP", "list", 3)
+    assert_equal ["3", "2", "1"], @redis.call("LRANGE", "list", 0, 3)
 
     error = assert_raises TypeError do
       @redis.pipelined { |p| p.call("LPUSH", "list", [1, [2, 3]]) }
@@ -271,7 +271,7 @@ module RedisClientTests
     error = assert_raises RedisClient::CommandError do
       @redis.call("DOESNOTEXIST", "foo")
     end
-    assert_includes error.message, "ERR unknown command `DOESNOTEXIST`"
+    assert_match(/ERR unknown command .DOESNOTEXIST./, error.message)
   end
 
   def test_authentication
@@ -394,7 +394,7 @@ module RedisClientTests
   end
 
   def test_blocking_call_timeout
-    assert_nil @redis.blocking_call(0.2, "BRPOP", "list", "0.1")
+    assert_nil @redis.blocking_call(0.5, "BRPOP", "list", "0.1")
     assert_equal "OK", @redis.call("SET", "foo", "bar")
   end
 

--- a/test/support/servers.rb
+++ b/test/support/servers.rb
@@ -20,7 +20,7 @@ module Servers
   SENTINEL_CONF_PATH = ServerManager::ROOT.join("tmp/sentinel.conf")
   SENTINEL_NAME = "cache"
 
-  DEFAULT_REDIS_VERSION = "6.2"
+  DEFAULT_REDIS_VERSION = "7.0"
 
   class << self
     def build_redis


### PR DESCRIPTION
It's not particularly useful since `redis-client` blindly serialize / deserialize and make almost 0 assumptions about the shape of commands etc.

But might as well as sometimes things like error messages can change etc.