### PR TITLE
Add support for RESP2

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ redis.call("GET", "mykey")
 - `read_timeout`: The read timeout, takes precedence over the general timeout when reading responses from the server.
 - `write_timeout`: The write timeout, takes precedence over the general timeout when sending commands to the server.
 - `reconnect_attempts`: Specify how many times the client should retry to send queries. Defaults to `0`. Makes sure to read the [reconnection section](#reconnection) before enabling it.
+- `protocol:` The version of the RESP protocol to use. Default to `3`.
 
 ### Sentinel support
 

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -537,7 +537,7 @@ class RedisClient
       begin
         @disable_reconnection = true
         yield connection
-      rescue ConnectionError => error
+      rescue ConnectionError
         connection&.close
         close
         raise
@@ -571,7 +571,9 @@ class RedisClient
       role, = connection.call_pipelined(prelude, nil).last
       config.check_role!(role)
     else
-      connection.call_pipelined(prelude, nil)
+      unless prelude.empty?
+        connection.call_pipelined(prelude, nil)
+      end
     end
 
     connection

--- a/lib/redis_client/ruby_connection/resp3.rb
+++ b/lib/redis_client/ruby_connection/resp3.rb
@@ -156,6 +156,8 @@ class RedisClient
     end
 
     def parse_sequence(io, size)
+      return if size < 0 # RESP2 nil
+
       array = Array.new(size)
       size.times do |index|
         array[index] = parse(io)
@@ -185,6 +187,8 @@ class RedisClient
 
     def parse_blob(io)
       bytesize = parse_integer(io)
+      return if bytesize < 0 # RESP2 nil type
+
       str = io.read_chomp(bytesize)
       str.force_encoding(Encoding.default_external)
       str.force_encoding(Encoding::BINARY) unless str.valid_encoding?

--- a/test/redis_client/resp2_client_test.rb
+++ b/test/redis_client/resp2_client_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RESP2ClientTest < Minitest::Test
+  include ClientTestHelper
+
+  def test_resp2_nil
+    @redis.call("SET", "foo", "bar")
+    assert_equal "bar", @redis.call("GETDEL", "foo")
+    assert_nil @redis.call("GET", "foo")
+  end
+
+  def test_limited_type_casting
+    assert_equal 1, @redis.call("INCR", "foo")
+    @redis.call("HMSET", "hash", "foo", "bar")
+    assert_equal ["foo", "bar"], @redis.call("HGETALL", "hash")
+  end
+
+  private
+
+  def new_client(**overrides)
+    RedisClient.config(**tcp_config, **overrides, protocol: 2).new_client
+  end
+end


### PR DESCRIPTION
Since apart from a few details RESP2 is a subset of RESP3 it doesn't cost much to support both.

This is mostly intended to let redis-rb use redis-client as a transport, but it may be useful for some limited use cases where the need for typecasting is light.