### PR TITLE
Fix URI parsing to support trailing slashes

### DIFF
--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -149,7 +149,7 @@ class RedisClient
           URI.decode_www_form_component(uri.password)
         end
 
-        kwargs[:db] ||= Integer(uri.path.delete_prefix("/")) if uri.path && !uri.path.empty?
+        kwargs[:db] ||= Integer(uri.path.delete_prefix("/")) if uri.path && !uri.path.empty? && uri.path != "/"
       end
 
       super(**kwargs)

--- a/test/redis_client/config_test.rb
+++ b/test/redis_client/config_test.rb
@@ -70,6 +70,13 @@ class RedisClient
       assert_predicate config, :ssl?
     end
 
+    def test_trailing_slash_url
+      config = Config.new(url: "redis://example.com/")
+      assert_equal 0, config.db
+      config = Config.new(url: "redis://[::1]/")
+      assert_equal 0, config.db
+    end
+
     def test_overriding
       config = Config.new(
         url: "redis://p%40ssw0rd@redis-16379.hosted.com:16379/12",


### PR DESCRIPTION
Hello – this modifies the client to support trailing slashes in the Redis URL. I think this is not technically a part of the [canonical scheme](https://www.iana.org/assignments/uri-schemes/prov/redis) for Redis URLs but is common in the wild.