### PR TITLE
Use `ruby2_keywords` for Pooled delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Workaround a bug in Ruby 2.6 causing a crash if the `debug` gem is enabled when `redis-client` is being required. Fix: #48
+
 # 0.8.0
 
 - Add a `connect` interface to the instrumentation API.


### PR DESCRIPTION
Rescuing SyntaxError seem to crash Ruby 2.6 if `ruby/debug` is enabled: https://github.com/redis-rb/redis-client/issues/47

Ultimately `ruby2_keywords` is simpler and faster, so might as well use it.

cc @st0012