### PR TITLE
Instance-level Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,11 @@ end
 
 ## Production
 
-### Instrumentation
+### Instrumentation and Middleware
 
-`redis-client` offers a public instrumentation API monitoring tools.
+`redis-client` offers a public middleware API to aid in monitoring and library extension. Middleware can be registered
+either globally or on a given configuration instance. When configured on the instance multiple middlewares may be
+registered.
 
 ```ruby
 module MyRedisInstrumentation
@@ -361,10 +363,24 @@ module MyRedisInstrumentation
     MyMonitoringService.instrument("redis.pipeline") { super }
   end
 end
-RedisClient.register(MyRedisInstrumentation)
-```
 
-Note that this instrumentation is global.
+module AnotherRedisInstrumentation
+  def call(command, redis_config)
+    MyHelperService.call(command, redis_config)
+    super
+  end
+end
+
+# Global middleware
+RedisClient.register(MyRedisInstrumentation)
+
+# Local middleware
+RedisClient.new(middleware: [MyRedisInstrumentation, AnotherRedisInstrumentation])
+# or
+redis_config = RedisClient.config
+redis_config.register(MyRedisInstrumentation)
+redis_config.register(AnotherRedisInstrumentation)
+```
 
 ### Timeouts
 

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -13,7 +13,8 @@ class RedisClient
 
     module Common
       attr_reader :db, :password, :id, :ssl, :ssl_params, :command_builder, :inherit_socket,
-        :connect_timeout, :read_timeout, :write_timeout, :driver, :connection_prelude, :protocol
+        :connect_timeout, :read_timeout, :write_timeout, :driver, :connection_prelude, :protocol,
+        :middlewares
 
       alias_method :ssl?, :ssl
 
@@ -33,7 +34,8 @@ class RedisClient
         client_implementation: RedisClient,
         command_builder: CommandBuilder,
         inherit_socket: false,
-        reconnect_attempts: false
+        reconnect_attempts: false,
+        middleware: nil
       )
         @username = username
         @password = password
@@ -60,6 +62,9 @@ class RedisClient
         reconnect_attempts = Array.new(reconnect_attempts, 0).freeze if reconnect_attempts.is_a?(Integer)
         @reconnect_attempts = reconnect_attempts
         @connection_prelude = build_connection_prelude
+
+        @middlewares = []
+        Array(middleware).tap(&:compact!).each { |mw| register(mw) }
       end
 
       def username
@@ -101,6 +106,10 @@ class RedisClient
         else
           "redis#{'s' if ssl?}://#{host}:#{port}/#{db}"
         end
+      end
+
+      def register(middleware)
+        @middlewares << RedisClient::Middlewares.dup.extend(middleware)
       end
 
       private

--- a/test/redis_client/middlewares_test.rb
+++ b/test/redis_client/middlewares_test.rb
@@ -12,8 +12,8 @@ class RedisClient
       new_module = @original_module.dup
       RedisClient.send(:remove_const, :Middlewares)
       RedisClient.const_set(:Middlewares, new_module)
-      RedisClient.register(TestMiddleware)
-      TestMiddleware.calls.clear
+      RedisClient.register(GlobalTestMiddleware)
+      CallCollection.calls.clear
     end
 
     def teardown
@@ -21,87 +21,137 @@ class RedisClient
         RedisClient.send(:remove_const, :Middlewares)
         RedisClient.const_set(:Middlewares, @original_module)
       end
-      TestMiddleware.calls.clear
+      CallCollection.calls.clear
       super
+    end
+
+    def redis_config
+      super(middleware: LocalTestMiddleware1).tap do |config|
+        config.register(LocalTestMiddleware2)
+      end
     end
 
     def test_call_instrumentation
       @redis.call("PING")
-      assert_call [:call, :success, ["PING"], "PONG", @redis.config]
+      assert_calls [
+        [:call, :success, ["PING"], "PONG", @redis.config, :local2],
+        [:call, :success, ["PING"], "PONG", @redis.config, :local1],
+        [:call, :success, ["PING"], "PONG", @redis.config, :global],
+      ]
     end
 
     def test_failing_call_instrumentation
       assert_raises CommandError do
         @redis.call("PONG")
       end
-      call = TestMiddleware.calls.first
-      assert_equal [:call, :error, ["PONG"]], call.first(3)
-      assert_instance_of CommandError, call[3]
+
+      local_call2 = CallCollection.calls[0]
+      assert_equal [:call, :error, ["PONG"]], local_call2.first(3)
+      assert_instance_of CommandError, local_call2[3]
+
+      local_call1 = CallCollection.calls[1]
+      assert_equal [:call, :error, ["PONG"]], local_call1.first(3)
+      assert_instance_of CommandError, local_call1[3]
+
+      global_call = CallCollection.calls[2]
+      assert_equal [:call, :error, ["PONG"]], global_call.first(3)
+      assert_instance_of CommandError, global_call[3]
     end
 
     def test_call_once_instrumentation
       @redis.call_once("PING")
-      assert_call [:call, :success, ["PING"], "PONG", @redis.config]
+      assert_calls [
+        [:call, :success, ["PING"], "PONG", @redis.config, :local2],
+        [:call, :success, ["PING"], "PONG", @redis.config, :local1],
+        [:call, :success, ["PING"], "PONG", @redis.config, :global],
+      ]
     end
 
     def test_blocking_call_instrumentation
       @redis.blocking_call(nil, "PING")
-      assert_call [:call, :success, ["PING"], "PONG", @redis.config]
+      assert_calls [
+        [:call, :success, ["PING"], "PONG", @redis.config, :local2],
+        [:call, :success, ["PING"], "PONG", @redis.config, :local1],
+        [:call, :success, ["PING"], "PONG", @redis.config, :global],
+      ]
     end
 
     def test_pipeline_instrumentation
       @redis.pipelined do |pipeline|
         pipeline.call("PING")
       end
-      assert_call [:pipeline, :success, [["PING"]], ["PONG"], @redis.config]
+      assert_calls [
+        [:pipeline, :success, [["PING"]], ["PONG"], @redis.config, :local2],
+        [:pipeline, :success, [["PING"]], ["PONG"], @redis.config, :local1],
+        [:pipeline, :success, [["PING"]], ["PONG"], @redis.config, :global],
+      ]
     end
 
     def test_multi_instrumentation
       @redis.multi do |transaction|
         transaction.call("PING")
       end
-      assert_call [
-        :pipeline,
-        :success,
-        [["MULTI"], ["PING"], ["EXEC"]],
-        ["OK", "QUEUED", ["PONG"]],
-        @redis.config,
+      assert_calls [
+        [:pipeline, :success, [["MULTI"], ["PING"], ["EXEC"]], ["OK", "QUEUED", ["PONG"]], @redis.config, :local2],
+        [:pipeline, :success, [["MULTI"], ["PING"], ["EXEC"]], ["OK", "QUEUED", ["PONG"]], @redis.config, :local1],
+        [:pipeline, :success, [["MULTI"], ["PING"], ["EXEC"]], ["OK", "QUEUED", ["PONG"]], @redis.config, :global],
       ]
     end
 
     private
 
-    def assert_call(call)
-      assert_equal call, TestMiddleware.calls.first
-      assert_equal 1, TestMiddleware.calls.size
-    end
-
     def assert_calls(calls)
-      assert_equal calls, TestMiddleware.calls
+      assert_equal calls, CallCollection.calls
     end
 
-    module TestMiddleware
+    module CallCollection
       class << self
         attr_accessor :calls
       end
       @calls = []
+    end
 
+    module BaseTestMiddleware
       def call(command, config)
         result = super
-        TestMiddleware.calls << [:call, :success, command, result, config]
+        CallCollection.calls << [:call, :success, command, result, config, middleware_class]
         result
       rescue => error
-        TestMiddleware.calls << [:call, :error, command, error, config]
+        CallCollection.calls << [:call, :error, command, error, config, middleware_class]
         raise
       end
 
       def call_pipelined(commands, config)
         result = super
-        TestMiddleware.calls << [:pipeline, :success, commands, result, config]
+        CallCollection.calls << [:pipeline, :success, commands, result, config, middleware_class]
         result
       rescue => error
-        TestMiddleware.calls << [:pipeline, :error, commands, error, config]
+        CallCollection.calls << [:pipeline, :error, commands, error, config, middleware_class]
         raise
+      end
+    end
+
+    module GlobalTestMiddleware
+      include BaseTestMiddleware
+
+      def middleware_class
+        :global
+      end
+    end
+
+    module LocalTestMiddleware1
+      include BaseTestMiddleware
+
+      def middleware_class
+        :local1
+      end
+    end
+
+    module LocalTestMiddleware2
+      include BaseTestMiddleware
+
+      def middleware_class
+        :local2
       end
     end
   end

--- a/test/support/client_test_helper.rb
+++ b/test/support/client_test_helper.rb
@@ -69,8 +69,12 @@ module ClientTestHelper
     }
   end
 
+  def redis_config(**overrides)
+    RedisClient.config(**tcp_config.merge(overrides))
+  end
+
   def new_client(**overrides)
-    RedisClient.new(**tcp_config.merge(overrides))
+    redis_config(**overrides).new_client
   end
 
   def simulate_network_errors(client, failures)


### PR DESCRIPTION
Our organization currently uses a small wrapper around `redis-rb` which provides a few extensions (for example, blocking `keys` calls in production by default and some automated instrumentation and error reporting). We'd love to switch our internal usage over to this `redis-client` library. The current middleware interface here is really nice and seems like it will make our "plugins" much easier to manage.

However, given that we use a library built on top of the redis gem we'd also like to scope our middleware to only our wrapper so that we're not impacting any other redis clients.

I implemented support here for instance-level middlewares. Is this something you'd be open to?