### PR TITLE
Add Instance level middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,12 +343,13 @@ end
 
 ## Production
 
-### Instrumentation
+### Instrumentation and Middlewares
 
-`redis-client` offers a public instrumentation API monitoring tools.
+`redis-client` offers a public middleware API to aid in monitoring and library extension. Middleware can be registered
+either globally or on a given configuration instance.
 
 ```ruby
-module MyRedisInstrumentation
+module MyGlobalRedisInstrumentation
   def connect(redis_config)
     MyMonitoringService.instrument("redis.connect") { super }
   end
@@ -361,10 +362,17 @@ module MyRedisInstrumentation
     MyMonitoringService.instrument("redis.pipeline") { super }
   end
 end
-RedisClient.register(MyRedisInstrumentation)
+RedisClient.register(MyGlobalRedisInstrumentation)
 ```
 
-Note that this instrumentation is global.
+Note that `RedisClient.register` is global and apply to all `RedisClient` instances.
+
+To add middlewares to only a single client, you can provide them when creating the config:
+
+```ruby
+redis_config = RedisClient.config(middlewares: [AnotherRedisInstrumentation])
+redis_config.new_client
+```
 
 ### Timeouts
 

--- a/benchmark/pipelined_hiredis.md
+++ b/benchmark/pipelined_hiredis.md
@@ -6,24 +6,24 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 ### small string
 
 ```
-            redis-rb:     4850.3 i/s
-        redis-client:     6132.4 i/s - 1.26x  (± 0.00) faster
+            redis-rb:     4841.5 i/s
+        redis-client:     6160.7 i/s - 1.27x  (± 0.00) faster
 
 ```
 
 ### large string
 
 ```
-            redis-rb:      369.3 i/s
-        redis-client:      408.0 i/s - 1.10x  (± 0.00) faster
+            redis-rb:      368.4 i/s
+        redis-client:      411.2 i/s - 1.12x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:     2743.1 i/s
-        redis-client:     3545.1 i/s - 1.29x  (± 0.00) faster
+            redis-rb:     2733.6 i/s
+        redis-client:     3493.2 i/s - 1.28x  (± 0.00) faster
 
 ```
 
@@ -31,23 +31,23 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 
 ```
             redis-rb:       73.2 i/s
-        redis-client:      101.5 i/s - 1.39x  (± 0.00) faster
+        redis-client:      103.0 i/s - 1.41x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:     2269.9 i/s
-        redis-client:     3958.9 i/s - 1.74x  (± 0.00) faster
+            redis-rb:     2222.9 i/s
+        redis-client:     4014.3 i/s - 1.81x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:       44.2 i/s
-        redis-client:       78.8 i/s - 1.78x  (± 0.00) faster
+            redis-rb:       44.4 i/s
+        redis-client:       79.0 i/s - 1.78x  (± 0.00) faster
 
 ```
 

--- a/benchmark/pipelined_ruby.md
+++ b/benchmark/pipelined_ruby.md
@@ -6,40 +6,40 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 ### small string
 
 ```
-            redis-rb:     1204.3 i/s
-        redis-client:     2823.3 i/s - 2.34x  (± 0.00) faster
+            redis-rb:     1214.3 i/s
+        redis-client:     2782.4 i/s - 2.29x  (± 0.00) faster
 
 ```
 
 ### large string
 
 ```
-            redis-rb:      248.3 i/s
-        redis-client:      365.9 i/s - 1.47x  (± 0.00) faster
+            redis-rb:      247.6 i/s
+        redis-client:      341.8 i/s - 1.38x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:      519.3 i/s
-        redis-client:     1126.6 i/s - 2.17x  (± 0.00) faster
+            redis-rb:      523.3 i/s
+        redis-client:     1120.3 i/s - 2.14x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:        2.4 i/s
-        redis-client:       12.8 i/s - 5.35x  (± 0.00) faster
+            redis-rb:        2.5 i/s
+        redis-client:       12.7 i/s - 5.17x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:      359.7 i/s
-        redis-client:     1029.2 i/s - 2.86x  (± 0.00) faster
+            redis-rb:      365.0 i/s
+        redis-client:     1024.4 i/s - 2.81x  (± 0.00) faster
 
 ```
 
@@ -47,7 +47,7 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 
 ```
             redis-rb:        2.3 i/s
-        redis-client:       12.6 i/s - 5.42x  (± 0.00) faster
+        redis-client:       12.5 i/s - 5.40x  (± 0.00) faster
 
 ```
 

--- a/benchmark/pipelined_yjit.md
+++ b/benchmark/pipelined_yjit.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 ### small string
 
 ```
-            redis-rb:     1459.1 i/s
-        redis-client:     4586.2 i/s - 3.14x  (± 0.00) faster
+            redis-rb:     1471.0 i/s
+        redis-client:     4573.8 i/s - 3.11x  (± 0.00) faster
 
 ```
 
 ### large string
 
 ```
-            redis-rb:      255.9 i/s
-        redis-client:      358.6 i/s - 1.40x  (± 0.00) faster
+            redis-rb:      257.0 i/s
+        redis-client:      364.7 i/s - 1.42x  (± 0.00) faster
 
 ```
 
 ### small list
 
 ```
-            redis-rb:      543.4 i/s
-        redis-client:     1787.4 i/s - 3.29x  (± 0.00) faster
+            redis-rb:      627.5 i/s
+        redis-client:     1744.3 i/s - 2.78x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:        2.4 i/s
-        redis-client:       24.5 i/s - 10.28x  (± 0.00) faster
+            redis-rb:        2.7 i/s
+        redis-client:       24.6 i/s - 9.16x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:      455.9 i/s
-        redis-client:     1699.0 i/s - 3.73x  (± 0.00) faster
+            redis-rb:      450.3 i/s
+        redis-client:     1713.8 i/s - 3.81x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:        2.6 i/s
-        redis-client:       21.1 i/s - 8.03x  (± 0.00) faster
+            redis-rb:        2.5 i/s
+        redis-client:       23.8 i/s - 9.42x  (± 0.00) faster
 
 ```
 

--- a/benchmark/single_hiredis.md
+++ b/benchmark/single_hiredis.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 ### small string
 
 ```
-            redis-rb:    45216.1 i/s
-        redis-client:    41666.2 i/s - same-ish: difference falls within error
+            redis-rb:    43966.6 i/s
+        redis-client:    41358.8 i/s - 1.06x  (± 0.00) slower
 
 ```
 
 ### large string
 
 ```
-            redis-rb:    22411.3 i/s
-        redis-client:    19881.4 i/s - 1.13x  (± 0.00) slower
+            redis-rb:    21595.5 i/s
+        redis-client:    19616.2 i/s - 1.10x  (± 0.00) slower
 
 ```
 
 ### small list
 
 ```
-            redis-rb:    41304.2 i/s
-        redis-client:    38191.0 i/s - 1.08x  (± 0.00) slower
+            redis-rb:    41283.0 i/s
+        redis-client:    38379.8 i/s - 1.08x  (± 0.00) slower
 
 ```
 
 ### large list
 
 ```
-            redis-rb:     7090.1 i/s
-        redis-client:     8554.6 i/s - 1.21x  (± 0.00) faster
+            redis-rb:     7091.0 i/s
+        redis-client:     8536.4 i/s - 1.20x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:    38593.2 i/s
-        redis-client:    38710.8 i/s - same-ish: difference falls within error
+            redis-rb:    38448.8 i/s
+        redis-client:    38752.6 i/s - same-ish: difference falls within error
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:     4685.1 i/s
-        redis-client:     6823.3 i/s - 1.46x  (± 0.00) faster
+            redis-rb:     4698.2 i/s
+        redis-client:     6802.4 i/s - 1.45x  (± 0.00) faster
 
 ```
 

--- a/benchmark/single_ruby.md
+++ b/benchmark/single_ruby.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 ### small string
 
 ```
-            redis-rb:    32121.5 i/s
-        redis-client:    33216.2 i/s - 1.03x  (± 0.00) faster
+            redis-rb:    32608.1 i/s
+        redis-client:    33285.7 i/s - same-ish: difference falls within error
 
 ```
 
 ### large string
 
 ```
-            redis-rb:    16819.8 i/s
-        redis-client:    18485.0 i/s - same-ish: difference falls within error
+            redis-rb:    16925.9 i/s
+        redis-client:    18477.8 i/s - same-ish: difference falls within error
 
 ```
 
 ### small list
 
 ```
-            redis-rb:    24153.5 i/s
-        redis-client:    27357.3 i/s - 1.13x  (± 0.00) faster
+            redis-rb:    24143.5 i/s
+        redis-client:    27307.6 i/s - 1.13x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:      321.8 i/s
-        redis-client:     1157.0 i/s - 3.60x  (± 0.00) faster
+            redis-rb:      327.6 i/s
+        redis-client:     1155.4 i/s - 3.53x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:    21626.5 i/s
-        redis-client:    26927.8 i/s - 1.25x  (± 0.00) faster
+            redis-rb:    21663.2 i/s
+        redis-client:    26989.6 i/s - 1.25x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:      302.9 i/s
-        redis-client:     1118.5 i/s - 3.69x  (± 0.00) faster
+            redis-rb:      306.1 i/s
+        redis-client:     1129.7 i/s - 3.69x  (± 0.00) faster
 
 ```
 

--- a/benchmark/single_yjit.md
+++ b/benchmark/single_yjit.md
@@ -6,48 +6,48 @@ redis-server: `Redis server v=7.0.4 sha=00000000:0 malloc=libc bits=64 build=ef6
 ### small string
 
 ```
-            redis-rb:    33850.0 i/s
-        redis-client:    34157.9 i/s - same-ish: difference falls within error
+            redis-rb:    33879.7 i/s
+        redis-client:    34618.9 i/s - same-ish: difference falls within error
 
 ```
 
 ### large string
 
 ```
-            redis-rb:    17181.2 i/s
-        redis-client:    19032.2 i/s - same-ish: difference falls within error
+            redis-rb:    17491.1 i/s
+        redis-client:    19211.4 i/s - same-ish: difference falls within error
 
 ```
 
 ### small list
 
 ```
-            redis-rb:    27435.4 i/s
-        redis-client:    30408.5 i/s - 1.11x  (± 0.00) faster
+            redis-rb:    27242.1 i/s
+        redis-client:    30271.4 i/s - 1.11x  (± 0.00) faster
 
 ```
 
 ### large list
 
 ```
-            redis-rb:      386.6 i/s
-        redis-client:     2061.7 i/s - 5.33x  (± 0.00) faster
+            redis-rb:      384.3 i/s
+        redis-client:     2050.7 i/s - 5.34x  (± 0.00) faster
 
 ```
 
 ### small hash
 
 ```
-            redis-rb:    23657.3 i/s
-        redis-client:    30254.9 i/s - 1.28x  (± 0.00) faster
+            redis-rb:    23513.7 i/s
+        redis-client:    30172.6 i/s - 1.28x  (± 0.00) faster
 
 ```
 
 ### large hash
 
 ```
-            redis-rb:      366.2 i/s
-        redis-client:     1932.8 i/s - 5.28x  (± 0.00) faster
+            redis-rb:      358.6 i/s
+        redis-client:     1916.3 i/s - 5.34x  (± 0.00) faster
 
 ```
 

--- a/lib/redis_client/middlewares.rb
+++ b/lib/redis_client/middlewares.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class RedisClient
-  module Middlewares
-    extend self
+  class BasicMiddleware
+    attr_reader :client
+
+    def initialize(client)
+      @client = client
+    end
 
     def connect(_config)
       yield
@@ -12,5 +16,8 @@ class RedisClient
       yield command
     end
     alias_method :call_pipelined, :call
+  end
+
+  class Middlewares < BasicMiddleware
   end
 end


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/pull/52

There are some use case for middlewares that only applies to a specific connection.

You could implement key namespacing as a middleware for instance, or use it to ban some commands etc, without impacting libraries that use redis-client too.

This can also be used to implement the Semian adapter as a middleware without any monkey patch.

I re-recorded the benchmark, and with this implementation there's no measurable perf impact.

The one downside of this implementation is that it makes it a bit harder for a middleware to be instantiated with some kind of configuration parameters, but it's not impossible at all.

Co-Authored-By: @gremerritt