### PR TITLE
Allow handling temporarily down redis nodes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     rubocop-minitest (0.19.1)
       rubocop (>= 0.90, < 2.0)
     ruby-progressbar (1.11.0)
-    stackprof (0.2.21)
+    stackprof (0.2.22)
     toxiproxy (2.0.2)
     unicode-display_width (2.2.0)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ redis.call("GET", "mykey")
 - `write_timeout`: The write timeout, takes precedence over the general timeout when sending commands to the server.
 - `reconnect_attempts`: Specify how many times the client should retry to send queries. Defaults to `0`. Makes sure to read the [reconnection section](#reconnection) before enabling it.
 - `protocol:` The version of the RESP protocol to use. Default to `3`.
+- `retry_connecting_delay:` The time in seconds to wait before attempting to reconnect. Defaults to `0`.
 
 ### Sentinel support
 

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -601,6 +601,12 @@ class RedisClient
   def ensure_connected(retryable: true)
     close if !config.inherit_socket && @pid != Process.pid
 
+    if config.delay_connecting?(@connection_error_at)
+      raise CannotConnectError, "retry_connecting_delay not reached"
+    else
+      @connection_error_at = false
+    end
+
     if @disable_reconnection
       if block_given?
         yield @raw_connection
@@ -684,6 +690,7 @@ class RedisClient
   rescue FailoverError
     raise
   rescue ConnectionError => error
+    @connection_error_at ||= Time.now
     raise CannotConnectError, error.message, error.backtrace
   rescue CommandError => error
     if error.message.include?("ERR unknown command `HELLO`")

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -36,7 +36,8 @@ class RedisClient
         command_builder: CommandBuilder,
         inherit_socket: false,
         reconnect_attempts: false,
-        middlewares: false
+        middlewares: false,
+        retry_connecting_delay: false
       )
         @username = username
         @password = password
@@ -74,6 +75,7 @@ class RedisClient
           end
         end
         @middlewares_stack = middlewares_stack
+        @retry_connecting_delay = retry_connecting_delay
       end
 
       def username
@@ -102,6 +104,16 @@ class RedisClient
             return true
           end
         end
+        false
+      end
+
+      def delay_connecting?(connection_error_at)
+        return false unless connection_error_at
+        return false unless @retry_connecting_delay
+
+        time_to_retry_connecting = connection_error_at + @retry_connecting_delay.seconds - Time.now
+        return true if time_to_retry_connecting.positive?
+
         false
       end
 


### PR DESCRIPTION
### Problem

When using redis as a caching solution on a remote server we don't always want to retry a connection, and wait for it to fail again, and would rather the cache call failed quickly.  The current option of `reconnect_attempts` is not useful here as we would have to wait for the connection to fail/timeout for every query which can quickly increase page load times.

### Proposed Solution

An option, `retry_connecting_delay`, that can be set to prevent the redis client from attempting a connection until the time limit is reached. This would enable the service using redis as a cache to quickly get back a cache miss greatly reducing the page load time. This attempts to acheive the same effect as the Dalli gems `down_retry_delay`[^1]

### Background

After making the transition from `ActiveSupport::Cache::MemcacheStore` to `ActiveSupport::Cache::RedisCacheStore` as a caching solution we noticed that the redis-client doesn't seem to handle dead nodes particularly well and will keep on attempting to connect to a node even if it gets back connection refused or other errors from it. When a server running a cache instance became unavailable (reboot, connection issue) it caused a significant drop in page load speeds as the cache would try to fetch from redis and eventually fail. Adding a `reconnect_attempts` only excerbates the problem as then we're waiting for the reconnect attempt and the eventual query to fail again. 

To solve this we introduced a patch to the redis client that rescues any connection error and places the connection in a 'waiting loop' so that each hit can quickly fail up to the time limt. Without the patch, every single attempt to read from redis was blocking for, say, 200ms, before raising a network error and causing a cache miss.

[^1]: https://github.com/petergoldstein/dalli/wiki/Dalli::Client-Options#failover--retry-options