### PR TITLE
hiredis: do not eagerly close the connection on read timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- hiredis: do not eagerly close the connection on read timeout, let the caller decide if a timeout is final.
 - Add `Config#extra` to store configuration metadata. It can be used for per server middleware configuration.
 
 # 0.10.0

--- a/test/redis_client/subscriptions_test.rb
+++ b/test/redis_client/subscriptions_test.rb
@@ -55,6 +55,16 @@ class RedisClient
       ], events
     end
 
+    def test_connection_lost
+      assert_nil @subscription.call("SUBSCRIBE", "mychannel")
+      @redis.call("PUBLISH", "mychannel", "event-0")
+      assert_equal ["subscribe", "mychannel", 1], @subscription.next_event
+      assert_equal ["message", "mychannel", "event-0"], @subscription.next_event
+
+      assert_nil @subscription.next_event(0.2)
+      assert_nil @subscription.next_event(0.2)
+    end
+
     def test_close
       assert_nil @subscription.call("SUBSCRIBE", "mychannel")
       @redis.pipelined do |pipeline|


### PR DESCRIPTION
Let the caller decide if a timeout is final, since sometimes a timeout is expected.

Ref: https://github.com/mperham/sidekiq/issues/5597

FYI: @doersf @mperham 

@doersf I was able to reproduce your issue, but I'd appreciate if you could try the fix before I cut a new release.