### PR TITLE
Workaround the Xcode 14 compilation issue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -192,3 +192,6 @@ Style/CombinableLoops:
 
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
+
+Style/CaseLikeIf:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- hiredis: Workaround a compilation bug with Xcode 14.0, Fix: #58
 - Accept `URI` instances as `uri` parameter.
 
 # 0.11.0

--- a/hiredis-client/ext/redis_client/hiredis/export.clang
+++ b/hiredis-client/ext/redis_client/hiredis/export.clang
@@ -1,2 +1,1 @@
 _Init_hiredis_connection
-_ruby_abi_version

--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -54,14 +54,12 @@ if RUBY_ENGINE == "ruby" && !RUBY_PLATFORM.match?(/mswin/)
     $CFLAGS << " -O3 "
   end
 
-  cc_version = `#{RbConfig::expand("$(CC) --version".dup)}`
+  cc_version = `#{RbConfig.expand("$(CC) --version".dup)}`
   if cc_version.match?(/clang/i)
-    unless RbConfig::CONFIG['DLDFLAGS'].to_s.include?("dynamic_lookup")
-      # Ref: https://github.com/redis-rb/redis-client/issues/58
-      # Ref: https://bugs.ruby-lang.org/issues/19005
-      $DLDFLAGS << ' -Wl,-undefined,dynamic_lookup '
-    end
     $LDFLAGS << ' -Wl,-exported_symbols_list,"' << File.join(__dir__, 'export.clang') << '"'
+    if RUBY_VERSION >= "3.2"
+      $LDFLAGS << " -Wl,-exported_symbol,_ruby_abi_version"
+    end
   elsif cc_version.match?(/gcc/i)
     $LDFLAGS << ' -Wl,--version-script="' << File.join(__dir__, 'export.gcc') << '"'
   end


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/58
Ref: https://bugs.ruby-lang.org/issues/19005

Rubies compiled with Xcode 14 are missing some flags in LDFLAGS which cause the hiredis gem to fail to compile.

We work around this by adding the flags back if we detect this bug.