### PR TITLE
Fix for Xcode 14 compilation issues

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/export.clang
+++ b/hiredis-client/ext/redis_client/hiredis/export.clang
@@ -1,2 +1,1 @@
 _Init_hiredis_connection
-_ruby_abi_version

--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -56,6 +56,7 @@ if RUBY_ENGINE == "ruby" && !RUBY_PLATFORM.match?(/mswin/)
 
   if `cc --version`.match?(/ clang /i) || RbConfig::CONFIG['CC'].match?(/clang/i)
     $LDFLAGS << ' -Wl,-exported_symbols_list,"' << File.join(__dir__, 'export.clang') << '"'
+    $LDFLAGS << " -Wl,-exported_symbol,_ruby_abi_version" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.2.0')
   elsif RbConfig::CONFIG['CC'].match?(/gcc/i)
     $LDFLAGS << ' -Wl,--version-script="' << File.join(__dir__, 'export.gcc') << '"'
   end


### PR DESCRIPTION
As described in https://bugs.ruby-lang.org/issues/19005, Ruby interpreters with XCode 14.0 will default without the `-Wl,undefined,dynamic_lookup` compilation flag enabled. As a result, any symbols that are not exported by the shared library will throw an error during linking.

hiredis-client was failing to build on these platforms because `_ruby_abi_version` is not exported in Ruby interpreters prior to 3.2.

To fix this, we need to export this symbol only if the Ruby version is
>= 3.2.0.

Closes #58