### PR TITLE
Reconnect on READONLY errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Close connection on READONLY errors. Fix: #64
 - Handle Redis 6+ servers with a missing HELLO command. See: #67
 - Validate `url` parameters a bit more strictly. Fix #61
 

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -90,8 +90,16 @@ class RedisClient
   WriteTimeoutError = Class.new(TimeoutError)
   CheckoutTimeoutError = Class.new(TimeoutError)
 
-  class CommandError < Error
+  module HasCommand
     attr_reader :command
+
+    def _set_command(command)
+      @command = command
+    end
+  end
+
+  class CommandError < Error
+    include HasCommand
 
     class << self
       def parse(error_message)
@@ -107,17 +115,15 @@ class RedisClient
         klass.new(error_message)
       end
     end
-
-    def _set_command(command)
-      @command = command
-    end
   end
 
   AuthenticationError = Class.new(CommandError)
   PermissionError = Class.new(CommandError)
-  ReadOnlyError = Class.new(CommandError)
   WrongTypeError = Class.new(CommandError)
   OutOfMemoryError = Class.new(CommandError)
+
+  ReadOnlyError = Class.new(ConnectionError)
+  ReadOnlyError.include(HasCommand)
 
   CommandError::ERRORS = {
     "WRONGPASS" => AuthenticationError,

--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -17,7 +17,7 @@ class RedisClient
       write(command)
       result = read(timeout)
       @pending_reads -= 1
-      if result.is_a?(CommandError)
+      if result.is_a?(Error)
         result._set_command(command)
         raise result
       else
@@ -37,7 +37,7 @@ class RedisClient
         timeout = timeouts && timeouts[index]
         result = read(timeout)
         @pending_reads -= 1
-        if result.is_a?(CommandError)
+        if result.is_a?(Error)
           result._set_command(commands[index])
           exception ||= result
         end

--- a/test/redis_client/connection_test.rb
+++ b/test/redis_client/connection_test.rb
@@ -300,6 +300,39 @@ class RedisClient
       server_thread&.kill
     end
 
+    def test_reconnect_on_readonly
+      tcp_server = TCPServer.new("127.0.0.1", 0)
+      tcp_server.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
+      port = tcp_server.addr[1]
+
+      server_thread = Thread.new do
+        session = tcp_server.accept
+        io = RubyConnection::BufferedIO.new(session, read_timeout: 1, write_timeout: 1)
+        while command = RESP3.load(io)
+          case command.first
+          when "HELLO"
+            session.write("_\r\n")
+          when "PING"
+            session.write("+PING\r\n")
+          when "SET"
+            session.write("-READONLY You can't write against a read only replica.\r\n")
+          else
+            session.write("-ERR Unknown command #{command.first}\r\n")
+          end
+        end
+        session.close
+      end
+
+      client = new_client(host: "127.0.0.1", port: port)
+      client.call("PING")
+      assert_raises RedisClient::ReadOnlyError do
+        client.call("SET", "foo", "bar")
+      end
+      refute_predicate client, :connected?
+    ensure
+      server_thread&.kill
+    end
+
     private
 
     def new_client(**overrides)


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/543
Fix: https://github.com/redis-rb/redis-client/issues/64

READONLY errors generally happens during failover scenarios and such and are likely to work after a reconnection.

Even if we're wrong and they're legitimate errors, they are safe to retry (maybe not in a pipeline).

NB: Just skething this out, this need a bit more testing. And also `redis-rb` will need a similar update in its error translation layer.

cc @yosiat