### PR TITLE
Update UnsupportedServer check

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -686,9 +686,9 @@ class RedisClient
   rescue ConnectionError => error
     raise CannotConnectError, error.message, error.backtrace
   rescue CommandError => error
-    if error.message.include?("ERR unknown command `HELLO`")
+    if error.message.match?(/ERR unknown command ('|`)HELLO('|`)/)
       raise UnsupportedServer,
-        "Your Redis server version is too old. redis-client requires Redis 6+. (#{config.server_url})"
+        "redis-client requires Redis 6+. with HELLO command available (#{config.server_url})"
     else
       raise
     end

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -63,7 +63,25 @@ class RedisClientTest < Minitest::Test
     error = assert_raises RedisClient::UnsupportedServer do
       client.call("PING")
     end
-    assert_includes error.message, "Your Redis server version is too old"
+    assert_includes error.message, "redis-client requires Redis 6+. with HELLO command available"
+  end
+
+  def test_redis_6_server_with_missing_hello_command
+    fake_redis6_driver = Class.new(RedisClient::RubyConnection) do
+      def call_pipelined(commands, *)
+        if commands.any? { |c| c == ["HELLO", "3"] }
+          raise RedisClient::CommandError, "ERR unknown command 'HELLO'"
+        else
+          super
+        end
+      end
+    end
+    client = new_client(driver: fake_redis6_driver)
+
+    error = assert_raises RedisClient::UnsupportedServer do
+      client.call("PING")
+    end
+    assert_includes error.message, "redis-client requires Redis 6+. with HELLO command available"
   end
 
   def test_handle_async_raise


### PR DESCRIPTION
* We are getting errors from redis like
  ERR unknown command 'HELLO' reported from the redis-client gem after
  updating our app to Sidekiq 7. After looking into the redis_client source
  code it looks like we test for that message to raise a more
  helpful UnsupportedServer error, but the string being tested for
  inlcludes back quotes where the error coming from the redis server
  includes single quotes
* Replace includes? with match? so we can use a regex to match the string
  with single or back quotes to raise the UnsupportedServer error.
* Update the UnsupportedServer error message to say that the server
  needs to be Redis 6+ with the HELLO command available since sometimes
  commands can be unavailable even in supported Redis versions