### PR TITLE
Implement circuit breakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add a `circuit_breaker` configuration option for cache servers and other disposable Redis servers. See #55 / #70
+
 # 0.11.2
 
 - Close connection on READONLY errors. Fix: #64

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -687,7 +687,7 @@ class RedisClient
     end
 
     connection
-  rescue FailoverError
+  rescue FailoverError, CannotConnectError
     raise
   rescue ConnectionError => error
     raise CannotConnectError, error.message, error.backtrace
@@ -702,5 +702,6 @@ class RedisClient
 end
 
 require "redis_client/pooled"
+require "redis_client/circuit_breaker"
 
 RedisClient.default_driver

--- a/lib/redis_client/circuit_breaker.rb
+++ b/lib/redis_client/circuit_breaker.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+class RedisClient
+  class CircuitBreaker
+    module Middleware
+      def connect(config)
+        config.circuit_breaker.protect { super }
+      end
+
+      def call(_command, config)
+        config.circuit_breaker.protect { super }
+      end
+
+      def call_pipelined(_commands, config)
+        config.circuit_breaker.protect { super }
+      end
+    end
+
+    OpenCircuitError = Class.new(CannotConnectError)
+
+    attr_reader :error_timeout, :error_threshold, :error_threshold_timeout, :success_threshold
+
+    def initialize(error_threshold:, error_timeout:, error_threshold_timeout: error_timeout, success_threshold: 0)
+      @error_threshold = Integer(error_threshold)
+      @error_threshold_timeout = Float(error_threshold_timeout)
+      @error_timeout = Float(error_timeout)
+      @success_threshold = Integer(success_threshold)
+      @errors = []
+      @successes = 0
+      @state = :closed
+      @lock = Mutex.new
+    end
+
+    def protect
+      if @state == :open
+        refresh_state
+      end
+
+      case @state
+      when :open
+        raise OpenCircuitError, "Too many connection errors happened recently"
+      when :closed
+        begin
+          yield
+        rescue ConnectionError
+          record_error
+          raise
+        end
+      when :half_open
+        begin
+          result = yield
+          record_success
+          result
+        rescue ConnectionError
+          record_error
+          raise
+        end
+      else
+        raise "[BUG] RedisClient::CircuitBreaker unexpected @state (#{@state.inspect}})"
+      end
+    end
+
+    private
+
+    def refresh_state
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      @lock.synchronize do
+        if @errors.last < (now - @error_timeout)
+          if @success_threshold > 0
+            @state = :half_open
+            @successes = 0
+          else
+            @errors.clear
+            @state = :closed
+          end
+        end
+      end
+    end
+
+    def record_error
+      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      expiry = now - @error_timeout
+      @lock.synchronize do
+        if @state == :closed
+          @errors.reject! { |t| t < expiry }
+        end
+        @errors << now
+        @successes = 0
+        if @state == :half_open || (@state == :closed && @errors.size >= @error_threshold)
+          @state = :open
+        end
+      end
+    end
+
+    def record_success
+      return unless @state == :half_open
+
+      @lock.synchronize do
+        return unless @state == :half_open
+
+        @successes += 1
+        if @successes >= @success_threshold
+          @state = :closed
+        end
+      end
+    end
+  end
+end

--- a/test/redis_client/circuit_breaker_test.rb
+++ b/test/redis_client/circuit_breaker_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RedisClient
+  class CircuitBreakerTest < Minitest::Test
+    include ClientTestHelper
+
+    def setup
+      @circuit_breaker = CircuitBreaker.new(
+        error_threshold: 3,
+        error_threshold_timeout: 2,
+        success_threshold: 2,
+        error_timeout: 1,
+      )
+    end
+
+    def test_open_circuit_after_consecutive_errors
+      open_circuit @circuit_breaker
+      assert_open @circuit_breaker
+    end
+
+    def test_allow_use_after_the_errors_timedout
+      open_circuit @circuit_breaker
+      assert_open @circuit_breaker
+
+      travel(@circuit_breaker.error_threshold_timeout) do
+        assert_closed(@circuit_breaker)
+      end
+    end
+
+    def test_reopen_immediately_when_half_open
+      open_circuit @circuit_breaker
+      assert_open @circuit_breaker
+
+      travel(@circuit_breaker.error_timeout) do
+        record_error(@circuit_breaker)
+        assert_open(@circuit_breaker)
+      end
+    end
+
+    def test_close_fully_after_success_threshold_is_reached
+      open_circuit @circuit_breaker
+      assert_open @circuit_breaker
+
+      travel(@circuit_breaker.error_timeout) do
+        @circuit_breaker.success_threshold.times do
+          assert_closed(@circuit_breaker)
+        end
+
+        record_error(@circuit_breaker)
+        assert_closed(@circuit_breaker)
+      end
+    end
+
+    private
+
+    def assert_open(circuit_breaker)
+      assert_raises CircuitBreaker::OpenCircuitError do
+        circuit_breaker.protect do
+          # noop
+        end
+      end
+    end
+
+    def assert_closed(circuit_breaker)
+      assert_equal(:result, circuit_breaker.protect { :result })
+    end
+
+    def open_circuit(circuit_breaker)
+      circuit_breaker.error_threshold.times do
+        record_error(circuit_breaker)
+      end
+    end
+
+    def record_error(circuit_breaker)
+      assert_raises CannotConnectError do
+        circuit_breaker.protect do
+          raise CannotConnectError, "Oh no!"
+        end
+      end
+    end
+  end
+end

--- a/test/support/client_test_helper.rb
+++ b/test/support/client_test_helper.rb
@@ -40,6 +40,11 @@ module ClientTestHelper
 
   private
 
+  def travel(seconds, &block)
+    now = Process.clock_gettime(Process::CLOCK_MONOTONIC) + seconds
+    Process.stub(:clock_gettime, now, &block)
+  end
+
   def tcp_config
     {
       host: Servers::HOST,


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/pull/55

When using Redis as a cache, if the server is having issues rather than to retry connecting many times, it's preferable to mark the server as unhealthy and to not to try to reconnect for a while.

~~NB: The code is mostly done, but I got sidetracked in the middle of the README changes, I'll try to finish tomorrow. FYI @DChalcraft~~

