### PR TITLE
Fix building of hiredis C extension on FreeBSD

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -55,7 +55,7 @@ if RUBY_ENGINE == "ruby" && !RUBY_PLATFORM.match?(/mswin/)
   end
 
   cc_version = `#{RbConfig.expand("$(CC) --version".dup)}`
-  if cc_version.match?(/clang/i)
+  if cc_version.match?(/clang/i) && RUBY_PLATFORM =~ /darwin/
     $LDFLAGS << ' -Wl,-exported_symbols_list,"' << File.join(__dir__, 'export.clang') << '"'
     if RUBY_VERSION >= "3.2"
       $LDFLAGS << " -Wl,-exported_symbol,_ruby_abi_version"


### PR DESCRIPTION
FreeBSD uses a version of clang that does not support the Darwin-specific `-Wl,-exported_symbols_list` linker flags. We can fix this by using the standard GCC flags (`-Wl,--version-script).

Closes #71