### PR TITLE
Update command builder to handle Array as an argument

### DIFF
--- a/lib/redis_client/command_builder.rb
+++ b/lib/redis_client/command_builder.rb
@@ -67,7 +67,7 @@ class RedisClient
 
         command.map! do |element|
           case element
-          when String
+          when String, Array
             element
           when Integer, Float, Symbol
             element.to_s


### PR DESCRIPTION
Fix for #76