### PR TITLE
Fix symbol missing build error on M1 on Ruby 3.2.0

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -57,7 +57,7 @@ if RUBY_ENGINE == "ruby" && !RUBY_PLATFORM.match?(/mswin/)
   cc_version = `#{RbConfig.expand("$(CC) --version".dup)}`
   if cc_version.match?(/clang/i) && RUBY_PLATFORM =~ /darwin/
     $LDFLAGS << ' -Wl,-exported_symbols_list,"' << File.join(__dir__, 'export.clang') << '"'
-    if RUBY_VERSION >= "3.2"
+    if RUBY_VERSION >= "3.2" && RUBY_PATCHLEVEL < 0
       $LDFLAGS << " -Wl,-exported_symbol,_ruby_abi_version"
     end
   elsif cc_version.match?(/gcc/i)


### PR DESCRIPTION
`_ruby_abi_version` is only exported on Ruby development builds. As noted in https://github.com/redis-rb/redis-client/issues/58#issuecomment-1367667097, this can best be determined by `RUBY_PATCHLEVEL`: it's -1 for development builds, and >=0 for released versions.