### PR TITLE
hiredis-client: use -fvisibility=hidden instead of -exported_symbols_list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         redis: ["6.2"]
-        ruby: ["3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0"]
+        ruby: ["ruby-head", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code

--- a/hiredis-client/ext/redis_client/hiredis/export.clang
+++ b/hiredis-client/ext/redis_client/hiredis/export.clang
@@ -1,1 +1,0 @@
-_Init_hiredis_connection

--- a/hiredis-client/ext/redis_client/hiredis/export.gcc
+++ b/hiredis-client/ext/redis_client/hiredis/export.gcc
@@ -1,7 +1,0 @@
-hiredis_connection_1.0 { 
-  global: 
-    Init_hiredis_connection;
-    ruby_abi_version;
-  local: 
-    *;
-};

--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -43,6 +43,7 @@ if RUBY_ENGINE == "ruby" && !RUBY_PLATFORM.match?(/mswin/)
       env["CFLAGS"] = concat_flags(env["CFLAGS"], "-I#{openssl_include}")
       env["SSL_LDFLAGS"] = "-L#{openssl_lib}"
     end
+    env["CFLAGS"] = concat_flags(env["CFLAGS"], "-fvisibility=hidden")
     env["OPTIMIZATION"] = "-g" if ENV["EXT_PEDANTIC"]
 
     env_args = env.map { |k, v| "#{k}=#{v}" }
@@ -51,23 +52,13 @@ if RUBY_ENGINE == "ruby" && !RUBY_PLATFORM.match?(/mswin/)
     end
   end
 
-  $CFLAGS = concat_flags($CFLAGS, "-I#{hiredis_dir}", "-std=c99")
+  $CFLAGS = concat_flags($CFLAGS, "-I#{hiredis_dir}", "-std=c99", "-fvisibility=hidden")
   $LDFLAGS = concat_flags($LDFLAGS, "-lssl", "-lcrypto")
   $libs = concat_flags($libs, "#{hiredis_dir}/libhiredis.a", "#{hiredis_dir}/libhiredis_ssl.a")
   $CFLAGS = if ENV["EXT_PEDANTIC"]
     concat_flags($CFLAGS, "-Werror", "-g")
   else
     concat_flags($CFLAGS, "-O3")
-  end
-
-  cc_version = `#{RbConfig.expand("$(CC) --version".dup)}`
-  if cc_version.match?(/clang/i) && RUBY_PLATFORM =~ /darwin/
-    $LDFLAGS << ' -Wl,-exported_symbols_list,"' << File.join(__dir__, 'export.clang') << '"'
-    if RUBY_VERSION >= "3.2" && RUBY_PATCHLEVEL < 0
-      $LDFLAGS << " -Wl,-exported_symbol,_ruby_abi_version"
-    end
-  elsif cc_version.match?(/gcc/i)
-    $LDFLAGS << ' -Wl,--version-script="' << File.join(__dir__, 'export.gcc') << '"'
   end
 
   append_cflags("-Wno-declaration-after-statement") # Older compilers

--- a/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
+++ b/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
@@ -726,7 +726,7 @@ static VALUE hiredis_close(VALUE self) {
     return Qnil;
 }
 
-void Init_hiredis_connection(void) {
+RUBY_FUNC_EXPORTED void Init_hiredis_connection(void) {
 #ifdef RUBY_ASSERT
         // Qfalse == NULL, so we can't return Qfalse in `reply_create_bool()`
         RUBY_ASSERT((void *)Qfalse == NULL);


### PR DESCRIPTION
Rather than to use an exported symbols list, we compile with -fvisibility=hidden and mark the init function with RUBY_FUNC_EXPORTED.

This was suggested by @nobu.

Ref: https://github.com/redis-rb/redis-client/issues/58#issuecomment-1397802949