### PR TITLE
Add missing test for block in `ensure_connected`.

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -642,7 +642,11 @@ class RedisClient
       connection = ensure_connected
       begin
         @disable_reconnection = true
-        yield connection
+        if block_given?
+          yield connection
+        else
+          connection
+        end
       rescue ConnectionError, ProtocolError
         close
         raise


### PR DESCRIPTION
Elsewhere in this method we test if a block was provided and only yield when necessary.  There's one case missing, this change address that missing case.