### PR TITLE
Cache Process.pid on Ruby 3.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Cache calls to `Process.pid` on Ruby 3.1+. #91.
+
 # 0.12.1
 
 - Improve compatibility with `uri 0.12.0` (default in Ruby 3.2.0).

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -3,6 +3,7 @@
 require "redis_client/version"
 require "redis_client/command_builder"
 require "redis_client/config"
+require "redis_client/pid_cache"
 require "redis_client/sentinel_config"
 require "redis_client/middlewares"
 
@@ -67,7 +68,7 @@ class RedisClient
       @read_timeout = read_timeout
       @write_timeout = write_timeout
       @command_builder = config.command_builder
-      @pid = Process.pid
+      @pid = PIDCache.pid
     end
 
     def timeout=(timeout)
@@ -609,7 +610,7 @@ class RedisClient
   end
 
   def ensure_connected(retryable: true)
-    close if !config.inherit_socket && @pid != Process.pid
+    close if !config.inherit_socket && @pid != PIDCache.pid
 
     if @disable_reconnection
       if block_given?
@@ -658,7 +659,7 @@ class RedisClient
   end
 
   def connect
-    @pid = Process.pid
+    @pid = PIDCache.pid
 
     connection = @middlewares.connect(config) do
       config.driver.new(

--- a/lib/redis_client/pid_cache.rb
+++ b/lib/redis_client/pid_cache.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class RedisClient
+  module PIDCache
+    if !Process.respond_to?(:fork) # JRuby or TruffleRuby
+      @pid = Process.pid
+      singleton_class.attr_reader(:pid)
+    elsif Process.respond_to?(:_fork) # Ruby 3.1+
+      class << self
+        attr_reader :pid
+
+        def update!
+          @pid = Process.pid
+        end
+      end
+      update!
+
+      module CoreExt
+        def _fork
+          child_pid = super
+          PIDCache.update! if child_pid == 0
+          child_pid
+        end
+      end
+      Process.singleton_class.prepend(CoreExt)
+    else # Ruby 3.0 or older
+      class << self
+        def pid
+          Process.pid
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/19443

Recent `glibc` no longer cache the PID, so every call to `Process.pid` end up emitting a syscall which as an impact on performance.

Ruby 3.3 may or may not do PID caching, in the meantime we can implement our own caching in Ruby 3.1+ using the `Process._fork` callback.

FYI: @dalehamel