### PR TITLE
Enable TCP keepalive on redis sockets.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -195,3 +195,6 @@ Style/DocumentDynamicEvalDefinition:
 
 Style/CaseLikeIf:
   Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Enable TCP keepalive on redis sockets. It sends a keep alive probe every 15 seconds for 2 minutes. #94.
+
 # 0.12.2
 
 - Cache calls to `Process.pid` on Ruby 3.1+. #91.

--- a/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
+++ b/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
@@ -480,7 +480,11 @@ static VALUE hiredis_connect_tcp(VALUE self, VALUE host, VALUE port) {
         redisFree(connection->context);
         connection->context = NULL;
     }
-    return hiredis_connect_finish(connection, redisConnectNonBlock(StringValuePtr(host), NUM2INT(port)));
+    redisContext *context = redisConnectNonBlock(StringValuePtr(host), NUM2INT(port));
+    if (context) {
+        redisEnableKeepAlive(context);
+    }
+    return hiredis_connect_finish(connection, context);
 }
 
 static VALUE hiredis_connect_unix(VALUE self, VALUE path) {

--- a/hiredis-client/ext/redis_client/hiredis/vendor/hiredis.c
+++ b/hiredis-client/ext/redis_client/hiredis/vendor/hiredis.c
@@ -913,7 +913,7 @@ int redisSetTimeout(redisContext *c, const struct timeval tv) {
 
 /* Enable connection KeepAlive. */
 int redisEnableKeepAlive(redisContext *c) {
-    if (redisKeepAlive(c, REDIS_KEEPALIVE_INTERVAL) != REDIS_OK)
+    if (redisKeepAlive(c, REDIS_KEEPALIVE_TTL, REDIS_KEEPALIVE_INTERVAL) != REDIS_OK)
         return REDIS_ERR;
     return REDIS_OK;
 }

--- a/hiredis-client/ext/redis_client/hiredis/vendor/hiredis.h
+++ b/hiredis-client/ext/redis_client/hiredis/vendor/hiredis.h
@@ -87,6 +87,7 @@ typedef long long ssize_t;
 #define REDIS_NO_AUTO_FREE 0x200
 
 #define REDIS_KEEPALIVE_INTERVAL 15 /* seconds */
+#define REDIS_KEEPALIVE_TTL 120 /* seconds */
 
 /* number of times we retry to connect in the case of EADDRNOTAVAIL and
  * SO_REUSEADDR is being used. */

--- a/hiredis-client/ext/redis_client/hiredis/vendor/net.h
+++ b/hiredis-client/ext/redis_client/hiredis/vendor/net.h
@@ -48,7 +48,7 @@ int redisContextConnectBindTcp(redisContext *c, const char *addr, int port,
                                const struct timeval *timeout,
                                const char *source_addr);
 int redisContextConnectUnix(redisContext *c, const char *path, const struct timeval *timeout);
-int redisKeepAlive(redisContext *c, int interval);
+int redisKeepAlive(redisContext *c, int ttl, int interval);
 int redisCheckConnectDone(redisContext *c, int *completed);
 
 int redisSetTcpNoDelay(redisContext *c);


### PR DESCRIPTION
Fix: https://github.com/redis/redis-rb/issues/1180

It sends a keep alive probe every 15 seconds for 2 minutes.

We could probably make it configurable, but that's some very advanced tuning, so I don't know if it's worth it.

If there's a need for it, let me know by commenting on this PR.