### PR TITLE
Fix #enable_socket_keep_alive on FreeBSD

### DIFF
--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -152,7 +152,7 @@ class RedisClient
     private_constant :KEEP_ALIVE_TTL
     private_constant :KEEP_ALIVE_PROBES
 
-    if %i[SOL_SOCKET TCP_KEEPIDLE TCP_KEEPINTVL TCP_KEEPCNT].all? { |c| Socket.const_defined? c } # Linux
+    if %i[SOL_TCP SOL_SOCKET TCP_KEEPIDLE TCP_KEEPINTVL TCP_KEEPCNT].all? { |c| Socket.const_defined? c } # Linux
       def enable_socket_keep_alive(socket)
         socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
         socket.setsockopt(Socket::SOL_TCP, Socket::TCP_KEEPIDLE, KEEP_ALIVE_INTERVAL)


### PR DESCRIPTION
Ruby on FreeBSD has all the SOL_SOCKET and TCP_* constants defined, but not SOL_TCP

So just add SOL_TCP to the array of constants tested for on Linux.