### PR TITLE
Implement RedisClient#measure_round_trip_delay

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -204,6 +204,14 @@ class RedisClient
     sub
   end
 
+  def measure_round_trip_delay
+    ensure_connected do |connection|
+      @middlewares.call(["PING"], config) do
+        connection.measure_round_trip_delay
+      end
+    end
+  end
+
   def call(*command, **kwargs)
     command = @command_builder.generate(command, kwargs)
     result = ensure_connected do |connection|

--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -101,6 +101,12 @@ class RedisClient
       raise ConnectionError, error.message
     end
 
+    def measure_round_trip_delay
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+      call(["PING"], @read_timeout)
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) - start
+    end
+
     private
 
     def connect

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -113,4 +113,12 @@ class RedisClientTest < Minitest::Test
       assert_equal i.to_s, @redis.call("GET", "key#{i}")
     end
   end
+
+  def test_measure_round_trip_delay
+    assert_equal "OK", @redis.call("SET", "foo", "bar")
+    assert_instance_of Float, @redis.measure_round_trip_delay
+    assert_equal "OK", @redis.call("SET", "foo", "bar")
+    @redis.close
+    assert_instance_of Float, @redis.measure_round_trip_delay
+  end
 end


### PR DESCRIPTION
Latency is returned as a Float in milliseconds.

For the Ruby driver, it's equivalent to measuring how long `call("PING")` takes, however with the Hiredis driver, the latency is measured without ever holding the GVL which allows to give a much more accurate measure that isn't impacted by GVL contention.

Ref: https://github.com/redis/hiredis-rb/issues/74

Test script:

```ruby
def fibonacci( n )
  return  n  if ( 0..1 ).include? n
  ( fibonacci( n - 1 ) + fibonacci( n - 2 ) )
end

require "redis-client"
if ENV["DRIVER"] == "hiredis"
  require "hiredis-client"
end

client = RedisClient.new

threads = 10.times.map do
  Thread.new do
    loop do
      fibonacci(30)
    end
  end
end

5.times do
  puts "latency: #{client.measure_round_trip_delay}ms"
  sleep 1
end
```

```
$ DRIVER=ruby bundle exec ruby -I hiredis-client/lib/ /tmp/measure-latency.rb
latency: 1033.9850000143051ms
latency: 1039.7799999713898ms
latency: 1040.0930000543594ms
latency: 1050.2749999761581ms
latency: 1044.6280000209808ms
```

```
$ DRIVER=hiredis bundle exec ruby -I hiredis-client/lib/ /tmp/measure-latency.rb
latency: 0.307ms
latency: 0.351ms
latency: 0.236ms
latency: 0.221ms
latency: 0.321ms
```

Note: I definitely see the usefulness of this, but it requires to bypass quite a few layers, which concerns me a bit in term of maintenance. But I'll sleep on it.

cc @mperham @nateberkopec