### PR TITLE
fix bug with sentinels and string arguments

### DIFF
--- a/lib/redis_client/sentinel_config.rb
+++ b/lib/redis_client/sentinel_config.rb
@@ -108,7 +108,7 @@ class RedisClient
         when String
           Config.new(**@client_config, **@extra_config, url: sentinel, db: nil)
         else
-          Config.new(**@client_config, **@extra_config, **sentinel, db: nil)
+          Config.new(**@client_config, **@extra_config, **sentinel.transform_keys(&:to_sym), db: nil)
         end
       end
     end

--- a/test/sentinel/sentinel_test.rb
+++ b/test/sentinel/sentinel_test.rb
@@ -222,6 +222,11 @@ class RedisClient
       assert_equal [Servers::REDIS.host, Servers::REDIS.port], [config.host, config.port]
     end
 
+    def test_config_with_string_arguments
+      config = new_config(sentinels: Servers::SENTINELS.map { |sentinel| { "host" => sentinel.host, "port" => sentinel.port } })
+      assert_equal Servers::SENTINELS.length, config.sentinels.length
+    end
+
     private
 
     def response_hash(hash)


### PR DESCRIPTION
### Description
There are integration bug with actioncable and redis-client with sentinels config.
It is possible to reproduce within this repo https://github.com/moofkit/actioncable-redis-sentinel-bug
```
$ bundle && bundle exec rails test
Running 1 tests in a single process (parallelization threshold is 50)
Run options: --seed 7348

# Running:

E

Error:
ActioncableTest#test_broadcasts_to_test_channel:
ArgumentError: unknown keywords: "host", "port"
    test/integration/actioncable_test.rb:5:in `block in <class:ActioncableTest>'

rails test test/integration/actioncable_test.rb:4

Finished in 0.043971s, 22.7423 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

The problem is [that config for the cable](https://github.com/moofkit/actioncable-redis-sentinel-bug/blob/ca59d09d7dc992a0685ca8f1f01ae27644cbd47f/config/cable.yml#L4-L6) is a YAML file and sentinels are deep nested hash in the sentinels array and even [`deep_symbolize_keys`](https://github.com/rails/rails/blob/07fdcbde557c364c407da437688fa7c82516a94f/railties/lib/rails/application.rb#LL226C26-L226C90) don't convert it to the symbols. So sentinels keys should be converted to symbol explicitly like in this fix
```ruby
# config/initializers/action_cable.rb
require "action_cable/subscription_adapter/redis"

# https://github.com/rails/rails/blob/da309a582e04183a85340ec0e1ed59b2d69ca9c2/actioncable/lib/action_cable/subscription_adapter/redis.rb#LL18C21-L18C61
ActionCable::SubscriptionAdapter::Redis.redis_connector = lambda do |config|
  # BUG: it needs to symbolize keys for redis gem >= 5.0.0
  config[:sentinels] = config[:sentinels].map(&:symbolize_keys) if config.key?(:sentinels)
  Redis.new(config.except(:adapter, :channel_prefix))
end
```

I'm not sure should it be fixed in actioncable or here, but this PR is a patch for redis-client to handle such configs without errors.
If this is not the right place, I will try to fix it on the rails side.