### PR TITLE
Make hiredis uses default CA certs

### DIFF
--- a/hiredis-client/lib/redis_client/hiredis_connection.rb
+++ b/hiredis-client/lib/redis_client/hiredis_connection.rb
@@ -10,6 +10,17 @@ class RedisClient
 
     class << self
       def ssl_context(ssl_params)
+        unless ssl_params[:ca_file] || ssl_params[:ca_path]
+          default_ca_file = OpenSSL::X509::DEFAULT_CERT_FILE
+          default_ca_path = OpenSSL::X509::DEFAULT_CERT_DIR
+
+          if File.readable? default_ca_file
+            ssl_params[:ca_file] = default_ca_file
+          elsif File.directory? default_ca_path
+            ssl_params[:ca_path] = default_ca_path
+          end
+        end
+
         HiredisConnection::SSLContext.new(
           ca_file: ssl_params[:ca_file],
           ca_path: ssl_params[:ca_path],


### PR DESCRIPTION
Using hiredis with `rediss://` url without explicitly specifying a CA file/directory fails with a quite obscure message:

`Resource temporarily unavailable`

After a bit of investigation I realized it was because hiredis wasn't configured with any CA, and wasn't using the default system ones.
Since the ruby implementation worked and uses the default system CA, here's a proposed fix to have a consistent behavior between hiredis and the ruby driver