### PR TITLE
Discard inherited connections on fork rather than close them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Discard sockets rather than explictly close them when a fork is detected.
 - Allow to configure sentinel client via url. #117.
 - Fix sentinel to preverse the auth/password when refreshing the sentinel list. #107.
 

--- a/hiredis-client/lib/redis_client/hiredis_connection.rb
+++ b/hiredis-client/lib/redis_client/hiredis_connection.rb
@@ -53,6 +53,11 @@ class RedisClient
       super
     end
 
+    def discard
+      _reopen
+      close
+    end
+
     def reconnect
       reconnected = begin
         _reconnect(@config.path, @config.ssl_context)

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -358,6 +358,11 @@ class RedisClient
     self
   end
 
+  def discard
+    @raw_connection&.discard
+    self
+  end
+
   def pipelined
     pipeline = Pipeline.new(@command_builder)
     yield pipeline
@@ -618,7 +623,7 @@ class RedisClient
   end
 
   def ensure_connected(retryable: true)
-    close if !config.inherit_socket && @pid != PIDCache.pid
+    discard if !config.inherit_socket && @pid != PIDCache.pid
 
     if @disable_reconnection
       if block_given?

--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -58,6 +58,13 @@ class RedisClient
       super
     end
 
+    def discard
+      unless @io.closed?
+        @io.reopen(File::NULL)
+      end
+      close
+    end
+
     def read_timeout=(timeout)
       @read_timeout = timeout
       @io.read_timeout = timeout if @io

--- a/lib/redis_client/ruby_connection/buffered_io.rb
+++ b/lib/redis_client/ruby_connection/buffered_io.rb
@@ -24,6 +24,10 @@ class RedisClient
         @io.to_io.close
       end
 
+      def reopen(*args)
+        @io.to_io.reopen(*args)
+      end
+
       def closed?
         @io.to_io.closed?
       end


### PR DESCRIPTION
Calling close can sometimes lead to `FIN` or `RST` being emitted.

If this happens original connection in the parent will be impacted.

To avoid this we use a classic `dup2(/dev/null) + close` dance.