### PR TITLE
SentinelConfig: handle role possibly being a string

### DIFF
--- a/lib/redis_client/sentinel_config.rb
+++ b/lib/redis_client/sentinel_config.rb
@@ -10,7 +10,7 @@ class RedisClient
     attr_reader :name
 
     def initialize(sentinels:, role: :master, name: nil, url: nil, **client_config)
-      unless %i(master replica slave).include?(role)
+      unless %i(master replica slave).include?(role.to_sym)
         raise ArgumentError, "Expected role to be either :master or :replica, got: #{role.inspect}"
       end
 
@@ -43,7 +43,7 @@ class RedisClient
       end
 
       @sentinels = {}.compare_by_identity
-      @role = role
+      @role = role.to_sym
       @mutex = Mutex.new
       @config = nil
 


### PR DESCRIPTION
sometimes the redis options are provided as a hash with string values.

This is true in my case where the configurations are read as a json object from an environment variable.

Given that only the role is expected to be a symbol, It is a much better user experience if the conversion was handled internally by the library instead of requiring the user to handle it themselves.