### PR TITLE
Add server_url to RedisClient

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -175,6 +175,10 @@ class RedisClient
     "#<#{self.class.name} #{config.server_url}#{id_string}>"
   end
 
+  def server_url
+    config.server_url
+  end
+
   def size
     1
   end

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -121,4 +121,8 @@ class RedisClientTest < Minitest::Test
     @redis.close
     assert_instance_of Float, @redis.measure_round_trip_delay
   end
+
+  def test_server_url
+    assert_equal "redis://#{Servers::HOST}:#{Servers::REDIS_TCP_PORT}/0", @redis.server_url
+  end
 end


### PR DESCRIPTION
redis-rb [expects the client to respond to `server_url`](https://github.com/redis/redis-rb/blob/master/lib/redis.rb#L111). This method was not implemented which broke inspection for redis-rb when used with in a sentinel configuration.