### PR TITLE
Introduces explicit auth credentials for sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Adds `sentinel_username` and `sentinel_password` options for `RedisClient#sentinel`
+
 # 0.16.0
 
 - Add `RedisClient#disable_reconnection`.
@@ -71,7 +73,7 @@
 
 - Make the client resilient to `Timeout.timeout` or `Thread#kill` use (it still is very much discouraged to use either).
   Use of async interrupts could cause responses to be interleaved.
-- hiredis: handle commands returning a top-level `false` (no command does this today, but some extensions might). 
+- hiredis: handle commands returning a top-level `false` (no command does this today, but some extensions might).
 - Workaround a bug in Ruby 2.6 causing a crash if the `debug` gem is enabled when `redis-client` is being required. Fix: #48
 
 # 0.8.0
@@ -90,7 +92,7 @@
 
 - Raise a distinct `RedisClient::OutOfMemoryError`, for Redis `OOM` errors.
 - Fix the instrumentation API to be called even for authentication commands.
-- Fix `url:` configuration to accept a trailing slash. 
+- Fix `url:` configuration to accept a trailing slash.
 
 # 0.7.1
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,41 @@ but a few so that if one is down the client will try the next one. The client
 is able to remember the last Sentinel that was able to reply correctly and will
 use it for the next requests.
 
+To [authenticate](https://redis.io/docs/management/sentinel/#configuring-sentinel-instances-with-authentication) Sentinel itself, you can specify the `sentinel_username` and `sentinel_password` options per instance. Exclude the `sentinel_username` option if you're using password-only authentication.
+
+```ruby
+SENTINELS = [{ host: '127.0.0.1', port: 26380},
+             { host: '127.0.0.1', port: 26381}]
+
+redis_config = RedisClient.sentinel(name: 'mymaster', sentinel_username: 'appuser', sentinel_password: 'mysecret', sentinels: SENTINELS, role: :master)
+```
+
+If you specify a username and/or password at the top level for your main Redis instance, Sentinel *will not* using thouse credentials
+
+```ruby
+# Use 'mysecret' to authenticate against the mymaster instance, but skip authentication for the sentinels:
+SENTINELS = [{ host: '127.0.0.1', port: 26380 },
+             { host: '127.0.0.1', port: 26381 }]
+
+redis_config = RedisClient.sentinel(name: 'mymaster', sentinels: SENTINELS, role: :master, password: 'mysecret')
+```
+
+So you have to provide Sentinel credential and Redis explictly even they are the same
+
+```ruby
+# Use 'mysecret' to authenticate against the mymaster instance and sentinel
+SENTINELS = [{ host: '127.0.0.1', port: 26380 },
+             { host: '127.0.0.1', port: 26381 }]
+
+redis_config = RedisClient.sentinel(name: 'mymaster', sentinels: SENTINELS, role: :master, password: 'mysecret', sentinel_password: 'mysecret')
+```
+
+Also the `name`, `password`, `username` and `db` for Redis instance can be passed as an url:
+
+```ruby
+redis_config = RedisClient.sentinel(url: "redis://appuser:mysecret@mymaster/10", sentinels: SENTINELS, role: :master)
+```
+
 ### Type support
 
 Only a select few Ruby types are supported as arguments beside strings.

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -159,6 +159,8 @@ class RedisClient
       host: nil,
       port: nil,
       path: nil,
+      username: nil,
+      password: nil,
       **kwargs
     )
       if url
@@ -171,9 +173,11 @@ class RedisClient
         }.compact.merge(kwargs)
         host ||= url_config.host
         port ||= url_config.port
+        username ||= url_config.username
+        password ||= url_config.password
       end
 
-      super(**kwargs)
+      super(username: username, password: password, **kwargs)
 
       @host = host || DEFAULT_HOST
       @port = Integer(port || DEFAULT_PORT)

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -167,8 +167,6 @@ class RedisClient
         url_config = URLConfig.new(url)
         kwargs = {
           ssl: url_config.ssl?,
-          username: url_config.username,
-          password: url_config.password,
           db: url_config.db,
         }.compact.merge(kwargs)
         host ||= url_config.host

--- a/test/support/servers.rb
+++ b/test/support/servers.rb
@@ -108,7 +108,7 @@ module Servers
         sentinel down-after-milliseconds #{SENTINEL_NAME} 10
         sentinel failover-timeout #{SENTINEL_NAME} 2000
         sentinel parallel-syncs #{SENTINEL_NAME} 1
-        user george on allcommands allkeys >hunter2
+        user alice on allcommands allkeys >superpassword
       EOS
     end
 


### PR DESCRIPTION
Related with https://github.com/redis/redis-rb/issues/1213#issuecomment-1683764044

This PR:
- introduces explicit `sentinel_username` and `sentinel_password` options for `RedisClient#sentinel`
- drops previous default behaviour by substitution credentials to Redis instance for Sentinel too (this may brake some client code that already relay on this)

I'm not sure about second change, so open to how make it better!

