### PR TITLE
Expose basic config details for RedisClient

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -179,6 +179,38 @@ class RedisClient
     config.server_url
   end
 
+  def id
+    config.id
+  end
+
+  def timeout
+    config.read_timeout
+  end
+
+  def db
+    config.db
+  end
+
+  def host
+    config.host unless config.path
+  end
+
+  def port
+    config.port unless config.path
+  end
+
+  def path
+    config.path
+  end
+
+  def username
+    config.username
+  end
+
+  def password
+    config.password
+  end
+
   def size
     1
   end

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -125,4 +125,41 @@ class RedisClientTest < Minitest::Test
   def test_server_url
     assert_equal "redis://#{Servers::HOST}:#{Servers::REDIS_TCP_PORT}/0", @redis.server_url
   end
+
+  def test_timeout
+    assert_equal 0.1, @redis.timeout
+  end
+
+  def test_db
+    assert_equal 0, @redis.db
+  end
+
+  def test_id
+    assert_nil @redis.id
+  end
+
+  def test_host
+    assert_equal Servers::HOST, @redis.host
+  end
+
+  def test_port
+    assert_equal Servers::REDIS_TCP_PORT, @redis.port
+  end
+
+  def test_path
+    client = new_client(**unix_config)
+    assert_equal Servers::REDIS_SOCKET_FILE.to_s, client.path
+  end
+
+  def test_username
+    username = "test"
+    client = new_client(**{ username: username })
+    assert_equal username, client.username
+  end
+
+  def test_password
+    password = "test"
+    client = new_client(**{ password: password })
+    assert_equal password, client.password
+  end
 end


### PR DESCRIPTION
This pull request exposes the basic configuration details on `RedisClient` via instance methods, referencing the configuration values in available in `Redis::Client` (https://github.com/redis/redis-rb/blob/2b183addb9175641a48e1d8616772282a31c0532/lib/redis/client.rb#L48-L82). 

This should close the gap between the raw `RedisClient` for sentinels and `Redis::Client` for standalone Redis. More context can be found in this issue: https://github.com/redis/redis-rb/issues/1231