### PR TITLE
Raise a useful error when reconnecting with a circuit breaker

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -678,7 +678,8 @@ class RedisClient
           connection
         end
       rescue ConnectionError, ProtocolError => error
-        preferred_error = error if preferred_error.nil? || !error.is_a?(CircuitBreaker::OpenCircuitError)
+        preferred_error ||= error 
+        preferred_error = error unless error.is_a?(CircuitBreaker::OpenCircuitError)
         close
 
         if !@disable_reconnection && config.retry_connecting?(tries, error)

--- a/test/redis_client/connection_test.rb
+++ b/test/redis_client/connection_test.rb
@@ -232,10 +232,10 @@ class RedisClient
       @redis = new_client(circuit_breaker: circuit_breaker, reconnect_attempts: 2)
 
       Toxiproxy[/redis/].down do
-        e = assert_raises CannotConnectError do
+        error = assert_raises CannotConnectError do
           @redis.call("PING")
         end
-        refute_instance_of CircuitBreaker::OpenCircuitError, e
+        refute_instance_of CircuitBreaker::OpenCircuitError, error
       end
     end
 

--- a/test/redis_client/connection_test.rb
+++ b/test/redis_client/connection_test.rb
@@ -227,6 +227,18 @@ class RedisClient
       end
     end
 
+    def test_circuit_breaker_initial_connection_exception
+      circuit_breaker = CircuitBreaker.new(error_threshold: 1, success_threshold: 1, error_timeout: 1)
+      @redis = new_client(circuit_breaker: circuit_breaker, reconnect_attempts: 2)
+
+      Toxiproxy[/redis/].down do
+        e = assert_raises CannotConnectError do
+          @redis.call("PING")
+        end
+        refute_instance_of CircuitBreaker::OpenCircuitError, e
+      end
+    end
+
     def test_killed_connection
       client = new_client(reconnect_attempts: 1, id: "background")
 


### PR DESCRIPTION
If you have reconnects enabled, and a circuit breaker configured, it's useful to raise the actual underlying error when we actually attempted the connection instead of simply the circuit breaker error. The circuit breaker error will still be raised if no attempts were tried.