### PR TITLE
hiredis_connection.c: Rename `unix` to `is_unix`

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
+++ b/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
@@ -592,7 +592,7 @@ static VALUE hiredis_connect(VALUE self, VALUE path, VALUE host, VALUE port, VAL
     return success;
 }
 
-static VALUE hiredis_reconnect(VALUE self, VALUE unix, VALUE ssl_param) {
+static VALUE hiredis_reconnect(VALUE self, VALUE is_unix, VALUE ssl_param) {
     CONNECTION(self, connection);
     if (!connection->context) {
         return Qfalse;
@@ -603,7 +603,7 @@ static VALUE hiredis_reconnect(VALUE self, VALUE unix, VALUE ssl_param) {
     VALUE success = hiredis_connect_finish(connection, connection->context);
 
     if (RTEST(success)) {
-        if (!RTEST(unix)) {
+        if (!RTEST(is_unix)) {
             redisEnableKeepAlive(connection->context);
         }
 


### PR DESCRIPTION
The `hiredis_reconnect` function is defined like this:

```
static VALUE hiredis_reconnect(VALUE self, VALUE unix, VALUE ssl_param)
```

However, `unix` is defined as a macro on some implementations, I found the issue in RHEL7 for ppc64le architecture.

When the macro is defined, the preprocessor replaces it by a `1`, and the function definition is transformed to this:

```
static VALUE hiredis_reconnect(VALUE self, VALUE 1, VALUE ssl_param) {
```

Which, on compile time fails with this error:

```
<command-line>:0:6: error: expected ';', ',' or ')' before numeric constant
hiredis_connection.c:595:50: note: in expansion of macro 'unix'
 static VALUE hiredis_reconnect(VALUE self, VALUE unix, VALUE ssl_param) {
                                                  ^
```

Just renaming the parameter fixes the issue for me.