### PR TITLE
close socket

### DIFF
--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -148,7 +148,7 @@ class RedisClient
       )
       true
     rescue SystemCallError, OpenSSL::SSL::SSLError, SocketError => error
-      socket.close if socket
+      socket&.close
       raise CannotConnectError, error.message, error.backtrace
     end
 

--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -148,6 +148,7 @@ class RedisClient
       )
       true
     rescue SystemCallError, OpenSSL::SSL::SSLError, SocketError => error
+      socket.close if socket
       raise CannotConnectError, error.message, error.backtrace
     end
 


### PR DESCRIPTION
If an error occurs during client connection, but after the socket is opened, isn't there a chance the socket could be left open? 