### PR TITLE
Draft: Replace bypass BufferedIO when `IO#timeout` is available

### DIFF
--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -97,6 +97,8 @@ class RedisClient
       end
     rescue RedisClient::RESP3::UnknownType => error
       raise RedisClient::ProtocolError, error.message
+    rescue IO::TimeoutError => error
+      raise RedisClient::ReadTimeoutError, error.message
     rescue SystemCallError, IOError, OpenSSL::SSL::SSLError => error
       raise ConnectionError, error.message
     end
@@ -141,7 +143,7 @@ class RedisClient
         end
       end
 
-      @io = BufferedIO.new(
+      @io = RubyConnection.buffered(
         socket,
         read_timeout: @read_timeout,
         write_timeout: @write_timeout,


### PR DESCRIPTION
Ruby IOs have an internal buffer already, the only reason we have to buffer again ourselves is to be able to timeout on `IO#gets`.

With `IO#timeout` being introduced in Ruby 3.2, we can get rid of the second buffer.

This is just a PoC, there is a handful of test failures, I just wanted to explore.

FYI: @ioquatix

One discovered issue is that we can't do that with `SSLSocket`: https://github.com/ruby/openssl/pull/693, to be explored further.