### PR TITLE
Add truffleruby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         redis: ["6.2"]
-        ruby: ["ruby-head", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0"]
+        ruby: ["ruby-head", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "jruby-9.3.6.0", "truffleruby"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code


### PR DESCRIPTION
From https://github.com/oracle/truffleruby/issues/3318
It seems to just work: https://github.com/eregon/redis-client/actions/runs/6881377522/job/18717592881