### PR TITLE
Fix compilation with multi-word $MAKE

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -47,7 +47,7 @@ class HiredisConnectionExtconf
 
     env_args = env.map { |k, v| "#{k}=#{v}" }
     Dir.chdir(hiredis_dir) do
-      unless system(make_program, "static", *env_args)
+      unless system(*Shellwords.split(make_program), "static", *env_args)
         raise "Building hiredis failed"
       end
     end


### PR DESCRIPTION
Bundler allows to override default make command with `$MAKE` and people for example use it to make compilation faster by using more jobs, eg `make -j4`. Usage like that is currently broken with hiredis client and this PR fixes it.