### PR TITLE
Fix a GC bug in hiredis-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fixed a GC bug that could cause crashes in `hiredis-client`.
+
 # 0.19.0
 
 - Revalidate connection in `RedisClient#connected?`


### PR DESCRIPTION
Since we only mark response values through the `stack` Array, these values are movable, so we can't trust the reply retuned by `redisGetReplyFromReader` as it may be outdated if the value was moved.

Instead we can directly take the first element of `stack` as it should be out response object.