### PR TITLE
Provide minimal Ractor compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Make basic usage Ractor compatible.
+
 # 0.19.1
 
 - Fixed a bug in `hiredis-client` that could cause a crash if interrupted by `Timeout.timeout` or other `Thread#raise` based mecanism.

--- a/lib/redis_client/ruby_connection/resp3.rb
+++ b/lib/redis_client/ruby_connection/resp3.rb
@@ -10,12 +10,12 @@ class RedisClient
 
     EOL = "\r\n".b.freeze
     EOL_SIZE = EOL.bytesize
-    DUMP_TYPES = { # rubocop:disable Style/MutableConstant
+    DUMP_TYPES = {
       String => :dump_string,
       Symbol => :dump_symbol,
       Integer => :dump_numeric,
       Float => :dump_numeric,
-    }
+    }.freeze
     PARSER_TYPES = {
       '#' => :parse_boolean,
       '$' => :parse_blob,
@@ -57,7 +57,7 @@ class RedisClient
     def dump_any(object, buffer)
       method = DUMP_TYPES.fetch(object.class) do |unexpected_class|
         if superclass = DUMP_TYPES.keys.find { |t| t > unexpected_class }
-          DUMP_TYPES[unexpected_class] = DUMP_TYPES[superclass]
+          DUMP_TYPES[superclass]
         else
           raise TypeError, "Unsupported command argument type: #{unexpected_class}"
         end

--- a/test/redis_client/ractor_test.rb
+++ b/test/redis_client/ractor_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RactorTest < Minitest::Test
+  def setup
+    skip("Ractors are not supported on this Ruby version") unless defined?(::Ractor)
+    skip("Hiredis is not Ractor safe") if RedisClient.default_driver.name == "RedisClient::HiredisConnection"
+    begin
+      Ractor.new { RedisClient.default_driver.name }.take
+    rescue Ractor::RemoteError
+      skip("Ractor implementation is too limited (MRI 3.0?)")
+    end
+  end
+
+  def test_get_and_set_within_ractor
+    ractor = Ractor.new do
+      within_ractor_redis = ClientTestHelper.new_client
+      within_ractor_redis.call("SET", "foo", "bar")
+      within_ractor_redis.call("GET", "foo")
+    end
+
+    assert_equal("bar", ractor.take)
+  end
+
+  def test_multiple_ractors
+    ractor1 = Ractor.new do
+      within_ractor_redis = ClientTestHelper.new_client
+      within_ractor_redis.call("SET", "foo", "bar")
+      within_ractor_redis.call("GET", "foo")
+    end
+
+    ractor1.take # We do this to ensure that the SET has been processed
+
+    ractor2 = Ractor.new do
+      key = Ractor.receive
+      within_ractor_redis = ClientTestHelper.new_client
+      within_ractor_redis.call("GET", key)
+    end
+    ractor2.send("foo")
+
+    assert_equal("bar", ractor2.take)
+  end
+end

--- a/test/support/raise_warnings.rb
+++ b/test/support/raise_warnings.rb
@@ -3,7 +3,10 @@
 $VERBOSE = true
 module RaiseWarnings
   def warn(message, *)
+    return if message.include?('Ractor is experimental')
+
     super
+
     raise message
   end
   ruby2_keywords :warn if respond_to?(:ruby2_keywords, true)


### PR DESCRIPTION
Addresses https://github.com/redis-rb/redis-client/issues/162 while keeping the ability to accept subclasses of accepted types as command arguments (https://github.com/redis-rb/redis-client/commit/9fb715fb1a3e1caf91d9b7fa921532085d47c707).

The tradeoff made is losing the cache on the subclass. I think this is reasonable as the length of DUMP_TYPES.keys is fixed to 4.