### PR TITLE
Ensure all elements of connection prelude are frozen

### DIFF
--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -151,6 +151,12 @@ class RedisClient
         if @db && @db != 0
           prelude << ["SELECT", @db.to_s]
         end
+
+        # Deep freeze all the strings and commands
+        prelude.map! do |commands|
+          commands = commands.map { |str| str.frozen? ? str : str.dup.freeze }
+          commands.freeze
+        end
         prelude.freeze
       end
     end

--- a/test/redis_client/config_test.rb
+++ b/test/redis_client/config_test.rb
@@ -74,6 +74,17 @@ class RedisClient
       refute_predicate config, :ssl?
     end
 
+    def test_frozen_prelude
+      config = Config.new(url: "redis://username:password@example.com")
+      prelude = config.connection_prelude
+      assert_equal true, prelude.frozen?
+      assert_equal true, (prelude.all? { |commands| commands.frozen? })
+
+      prelude.each do |commands|
+        assert_equal true, (commands.all? { |arg| arg.frozen? })
+      end
+    end
+
     def test_simple_password_uri
       config = Config.new(url: "redis://password@example.com")
       assert_equal "example.com", config.host


### PR DESCRIPTION
We ran into a production issue when upgrading the `redis` gem from v4.8.0 to v5.0.2. Our instrumentation is based on
[peek-redis](https://github.com/peek/peek-redis), which patches `Redis::Client#call`. The instrumentation stores the Redis command and redacts the password from the `AUTH` command.

In v4.8.0, it was safe to alter the command since it was already sent on the wire and discarded.

However, in v5.0, `Redis::Client` now inherits from `RedisClient` from this gem, and `RedisClient::Config#connection_prelude` is used to establish a connection. While the prelude array was frozen, the
command arrays themselves were not. As a result, the instrumentation inadvertently altered the `AUTH` password. This resulted in `WRONGPASS` and `NOAUTH` errors upon a reconnect.

To prevent clients from mucking with the prelude, freeze all the elements as well.