### PR TITLE
Improve error log message output

### DIFF
--- a/hiredis-client/lib/redis_client/hiredis_connection.rb
+++ b/hiredis-client/lib/redis_client/hiredis_connection.rb
@@ -39,6 +39,8 @@ class RedisClient
       end
     end
 
+    attr_reader :config
+
     def initialize(config, connect_timeout:, read_timeout:, write_timeout:)
       super()
       @config = config
@@ -98,14 +100,20 @@ class RedisClient
         end
       end
     rescue SystemCallError, IOError => error
-      raise ConnectionError, error.message
+      raise ConnectionError.with_config(error.message, config)
+    rescue Error => error
+      error._set_config(config)
+      raise error
     end
 
     def write(command)
       _write(command)
       flush
     rescue SystemCallError, IOError => error
-      raise ConnectionError, error.message
+      raise ConnectionError.with_config(error.message, config)
+    rescue Error => error
+      error._set_config(config)
+      raise error
     end
 
     def write_multi(commands)
@@ -114,7 +122,10 @@ class RedisClient
       end
       flush
     rescue SystemCallError, IOError => error
-      raise ConnectionError, error.message
+      raise ConnectionError.with_config(error.message, config)
+    rescue Error => error
+      error._set_config(config)
+      raise error
     end
 
     private

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -124,10 +124,17 @@ class RedisClient
 
       def server_url
         if path
-          "#{path}/#{db}"
+          url = "unix://#{path}"
+          if db != 0
+            url = "#{url}?db=#{db}"
+          end
         else
-          "redis#{'s' if ssl?}://#{host}:#{port}/#{db}"
+          url = "redis#{'s' if ssl?}://#{host}:#{port}"
+          if db != 0
+            url = "#{url}/#{db}"
+          end
         end
+        url
       end
 
       private

--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -32,6 +32,7 @@ class RedisClient
       @pending_reads -= 1
       if result.is_a?(Error)
         result._set_command(command)
+        result._set_config(config)
         raise result
       else
         result
@@ -53,10 +54,16 @@ class RedisClient
 
         # A multi/exec command can return an array of results.
         # An error from a multi/exec command is handled in Multi#_coerce!.
-        if result.is_a?(Error)
+        if result.is_a?(Array)
+          result.each do |res|
+            res._set_config(config) if res.is_a?(Error)
+          end
+        elsif result.is_a?(Error)
           result._set_command(commands[index])
+          result._set_config(config)
           exception ||= result
         end
+
         results[index] = result
       end
 

--- a/test/redis_client/config_test.rb
+++ b/test/redis_client/config_test.rb
@@ -198,13 +198,13 @@ class RedisClient
     end
 
     def test_server_url
-      assert_equal "redis://localhost:6379/0", Config.new.server_url
-      assert_equal "redis://localhost:6379/0", Config.new(username: "george", password: "hunter2").server_url
+      assert_equal "redis://localhost:6379", Config.new.server_url
+      assert_equal "redis://localhost:6379", Config.new(username: "george", password: "hunter2").server_url
       assert_equal "redis://localhost:6379/5", Config.new(db: 5).server_url
-      assert_equal "redis://example.com:8080/0", Config.new(host: "example.com", port: 8080).server_url
-      assert_equal "rediss://localhost:6379/0", Config.new(ssl: true).server_url
+      assert_equal "redis://example.com:8080", Config.new(host: "example.com", port: 8080).server_url
+      assert_equal "rediss://localhost:6379", Config.new(ssl: true).server_url
 
-      assert_equal "/var/redis/redis.sock/5", Config.new(path: "/var/redis/redis.sock", db: 5).server_url
+      assert_equal "unix:///var/redis/redis.sock?db=5", Config.new(path: "/var/redis/redis.sock", db: 5).server_url
     end
 
     def test_custom_field

--- a/test/redis_client/connection_test.rb
+++ b/test/redis_client/connection_test.rb
@@ -26,26 +26,32 @@ class RedisClient
 
     def test_connect_failure
       client = new_client(host: "example.com")
-      assert_raises RedisClient::ConnectionError do
+      error = assert_raises RedisClient::ConnectionError do
         client.call("PING")
       end
+
+      assert_match(%r{ \(rediss?://example.com:.*\)$}, error.message)
     end
 
     def test_redis_down_after_connect
       @redis.call("PING") # force connect
       Toxiproxy[/redis/].down do
-        assert_raises RedisClient::ConnectionError do
+        error = assert_raises RedisClient::ConnectionError do
           @redis.call("PING")
         end
+
+        assert_match(%r{ \(rediss?://127.0.0.1:.*\)$}, error.message)
       end
     end
 
     def test_redis_down_before_connect
       @redis.close
       Toxiproxy[/redis/].down do
-        assert_raises RedisClient::ConnectionError do
+        error = assert_raises RedisClient::ConnectionError do
           @redis.call("PING")
         end
+
+        assert_match(%r{ \(rediss?://127.0.0.1:.*\)$}, error.message)
       end
     end
 
@@ -291,9 +297,11 @@ class RedisClient
 
     def test_connecting_to_a_ssl_server
       client = new_client(**ssl_config, ssl: false)
-      assert_raises CannotConnectError do
+      error = assert_raises CannotConnectError do
         client.call("PING")
       end
+
+      assert_match(%r{ \(rediss?://.*:.*\)$}, error.message)
     end
 
     def test_protocol_error
@@ -307,9 +315,11 @@ class RedisClient
         session.close
       end
 
-      assert_raises RedisClient::ProtocolError do
+      error = assert_raises RedisClient::ProtocolError do
         new_client(host: "127.0.0.1", port: port).call("PING")
       end
+
+      assert_match(%r{ \(rediss?://127.0.0.1:#{port}/0\)$}, error.message)
     ensure
       server_thread&.kill
     end
@@ -372,10 +382,11 @@ class RedisClient
 
       client = new_client(host: "127.0.0.1", port: port)
       client.call("PING")
-      assert_raises RedisClient::ReadOnlyError do
+      error = assert_raises RedisClient::ReadOnlyError do
         client.call("SET", "foo", "bar")
       end
       refute_predicate client, :connected?
+      assert_match(%r{ \(rediss?://127.0.0.1:#{port}/0\)$}, error.message)
     ensure
       server_thread&.kill
     end

--- a/test/redis_client/connection_test.rb
+++ b/test/redis_client/connection_test.rb
@@ -319,7 +319,7 @@ class RedisClient
         new_client(host: "127.0.0.1", port: port).call("PING")
       end
 
-      assert_match(%r{ \(rediss?://127.0.0.1:#{port}/0\)$}, error.message)
+      assert_match(%r{ \(rediss?://127.0.0.1:#{port}\)$}, error.message)
     ensure
       server_thread&.kill
     end
@@ -386,7 +386,7 @@ class RedisClient
         client.call("SET", "foo", "bar")
       end
       refute_predicate client, :connected?
-      assert_match(%r{ \(rediss?://127.0.0.1:#{port}/0\)$}, error.message)
+      assert_match(%r{ \(rediss?://127.0.0.1:#{port}\)$}, error.message)
     ensure
       server_thread&.kill
     end

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -43,9 +43,11 @@ class RedisClientTest < Minitest::Test
 
   def test_dns_resolution_failure
     client = RedisClient.new(host: "does-not-exist.example.com")
-    assert_raises RedisClient::ConnectionError do
+    error = assert_raises RedisClient::ConnectionError do
       client.call("PING")
     end
+
+    assert_match(%r{ \(redis://does-not-exist.example.com:.*\)$}, error.message)
   end
 
   def test_older_server
@@ -64,6 +66,7 @@ class RedisClientTest < Minitest::Test
       client.call("PING")
     end
     assert_includes error.message, "redis-client requires Redis 6+ with HELLO command available"
+    assert_includes error.message, "(redis://"
   end
 
   def test_redis_6_server_with_missing_hello_command
@@ -82,6 +85,7 @@ class RedisClientTest < Minitest::Test
       client.call("PING")
     end
     assert_includes error.message, "redis-client requires Redis 6+ with HELLO command available"
+    assert_includes error.message, "(redis://"
   end
 
   def test_handle_async_raise

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -127,7 +127,7 @@ class RedisClientTest < Minitest::Test
   end
 
   def test_server_url
-    assert_equal "redis://#{Servers::HOST}:#{Servers::REDIS_TCP_PORT}/0", @redis.server_url
+    assert_equal "redis://#{Servers::HOST}:#{Servers::REDIS_TCP_PORT}", @redis.server_url
   end
 
   def test_timeout

--- a/test/shared/redis_client_tests.rb
+++ b/test/shared/redis_client_tests.rb
@@ -271,7 +271,7 @@ module RedisClientTests
       @redis.call("SISMEMBER", "str", "member")
     end
     assert_equal ["SISMEMBER", "str", "member"], error.command
-    assert_includes error.message, "WRONGTYPE Operation against a key holding the wrong kind of value"
+    assert_match(/WRONGTYPE Operation against a key holding the wrong kind of value (.*:.*)/, error.message)
 
     error = assert_raises RedisClient::CommandError do
       @redis.pipelined do |pipeline|
@@ -279,7 +279,7 @@ module RedisClientTests
       end
     end
     assert_equal ["SISMEMBER", "str", "member"], error.command
-    assert_includes error.message, "WRONGTYPE Operation against a key holding the wrong kind of value"
+    assert_match(/WRONGTYPE Operation against a key holding the wrong kind of value (.*:.*)/, error.message)
 
     error = assert_raises RedisClient::CommandError do
       @redis.multi do |transaction|
@@ -287,14 +287,14 @@ module RedisClientTests
       end
     end
     assert_equal ["SISMEMBER", "str", "member"], error.command
-    assert_includes error.message, "WRONGTYPE Operation against a key holding the wrong kind of value"
+    assert_match(/WRONGTYPE Operation against a key holding the wrong kind of value (.*:.*)/, error.message)
   end
 
   def test_command_missing
     error = assert_raises RedisClient::CommandError do
       @redis.call("DOESNOTEXIST", "foo")
     end
-    assert_match(/ERR unknown command .DOESNOTEXIST./, error.message)
+    assert_match(/ERR unknown command .DOESNOTEXIST.*\(.*:.*\)/, error.message)
   end
 
   def test_authentication


### PR DESCRIPTION
Previously when an error were received by a Redis server, it was not clear whether this came from a Redis Sentinel or a Redis server in the cluster. This commit adds the hostname/port of the server to the exception message via a log context.

Closes https://github.com/redis-rb/redis-client/issues/177