### PR TITLE
Add unit test/comment for multi/exec handling

### DIFF
--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -50,6 +50,9 @@ class RedisClient
         timeout = timeouts && timeouts[index]
         result = read(timeout)
         @pending_reads -= 1
+
+        # A multi/exec command can return an array of results.
+        # An error from a multi/exec command is handled in Multi#_coerce!.
         if result.is_a?(Error)
           result._set_command(commands[index])
           exception ||= result

--- a/test/shared/redis_client_tests.rb
+++ b/test/shared/redis_client_tests.rb
@@ -278,6 +278,7 @@ module RedisClientTests
         pipeline.call("SISMEMBER", "str", "member")
       end
     end
+    assert_equal ["SISMEMBER", "str", "member"], error.command
     assert_includes error.message, "WRONGTYPE Operation against a key holding the wrong kind of value"
 
     error = assert_raises RedisClient::CommandError do
@@ -285,6 +286,7 @@ module RedisClientTests
         transaction.call("SISMEMBER", "str", "member")
       end
     end
+    assert_equal ["SISMEMBER", "str", "member"], error.command
     assert_includes error.message, "WRONGTYPE Operation against a key holding the wrong kind of value"
   end
 


### PR DESCRIPTION
In a mulit/exec command, the results of `call_pipelined` can be an array. It was not obvious to me this was handled outside of the `ConnectionMixin`. This commit adds a unit test to ensure the commands for an error are stored properly in this case and a comment mentioning that the results are handled in `Multi#_coerce!`.