### PR TITLE
Rescue OpenSSL::SSL::SSLError for write and write_multi

### DIFF
--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -74,7 +74,7 @@ class RedisClient
       buffer = RESP3.dump(command)
       begin
         @io.write(buffer)
-      rescue SystemCallError, IOError => error
+      rescue SystemCallError, IOError, OpenSSL::SSL::SSLError => error
         raise ConnectionError.with_config(error.message, config)
       end
     end
@@ -86,7 +86,7 @@ class RedisClient
       end
       begin
         @io.write(buffer)
-      rescue SystemCallError, IOError => error
+      rescue SystemCallError, IOError, OpenSSL::SSL::SSLError => error
         raise ConnectionError.with_config(error.message, config)
       end
     end


### PR DESCRIPTION
While on version 4 of the `redis` gem, we had a monkey patch to rescue `SSL_read: shutdown while in init` errors as suggested here: https://github.com/redis/redis-rb/issues/1174#issuecomment-1412993295

This worked fine until we upgrade to `redis` version 5 and our patch wasn't being applied anymore. We recently have been seeing: `SSL_write: shutdown while in init` (notice that it's `write` instead of `read`). I realized that the redis-client code was rescuing SSL errors for the `read`: https://github.com/redis-rb/redis-client/blob/master/lib/redis_client/ruby_connection.rb#L102

But it wasn't doing it for `write`. This PR adds rescuing of `OpenSSL::SSL::SSLError` to `write` and `write_multi`.