### PR TITLE
Handle unresolved Sentinel master/replica error

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -85,7 +85,7 @@ class RedisClient
     end
 
     def message
-      return super unless config
+      return super unless config&.resolved?
 
       "#{super} (#{config.server_url})"
     end

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -91,6 +91,10 @@ class RedisClient
         @username || DEFAULT_USERNAME
       end
 
+      def resolved?
+        true
+      end
+
       def sentinel?
         false
       end

--- a/lib/redis_client/sentinel_config.rb
+++ b/lib/redis_client/sentinel_config.rb
@@ -112,6 +112,12 @@ class RedisClient
       end
     end
 
+    def resolved?
+      @mutex.synchronize do
+        !!@config
+      end
+    end
+
     private
 
     def sentinels_to_configs(sentinels)


### PR DESCRIPTION
https://github.com/redis-rb/redis-client/pull/178 introduced a regression that caused a `ConnectionError` to be thrown to the caller if the Sentinel master or replica could not be resolved.

When a `ConnectionError` is thrown, the error message handler would attempt to retrieve `config.server_url`, but this in turn causes another Sentinel resolution to be attempted.

We avoid this by adding a `resolved?` method that will indicate whether the config can be used. The error handler won't attempt to provide more details if the config has yet to be resolved.

Closes #182