### PR TITLE
Various Ruby driver optimizations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,9 @@ Lint/UnderscorePrefixedVariableName:
 Lint/EmptyBlock:
   Enabled: false
 
+Lint/DuplicateBranch:
+  Enabled: false
+
 Lint/MissingSuper:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,12 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Style/InfiniteLoop:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 

--- a/Rakefile
+++ b/Rakefile
@@ -71,12 +71,15 @@ namespace :hiredis do
   end
 end
 
-benchmark_suites = %w(single pipelined)
+benchmark_suites = %w(single pipelined drivers)
 benchmark_modes = %i[ruby yjit hiredis]
 namespace :benchmark do
   benchmark_suites.each do |suite|
     benchmark_modes.each do |mode|
+      next if suite == "drivers" && mode == :hiredis
+
       name = "#{suite}_#{mode}"
+      desc name
       task name do
         output_path = "benchmark/#{name}.md"
         sh "rm", "-f", output_path

--- a/benchmark/drivers.rb
+++ b/benchmark/drivers.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "setup"
+
+ruby = RedisClient.new(host: "localhost", port: Servers::REDIS.real_port, driver: :ruby)
+hiredis = RedisClient.new(host: "localhost", port: Servers::REDIS.real_port, driver: :hiredis)
+
+ruby.call("SET", "key", "value")
+ruby.call("SET", "large", "value" * 10_000)
+ruby.call("LPUSH", "list", *5.times.to_a)
+ruby.call("LPUSH", "large-list", *1000.times.to_a)
+ruby.call("HMSET", "hash", *8.times.to_a)
+ruby.call("HMSET", "large-hash", *1000.times.to_a)
+
+benchmark("small string x 100") do |x|
+  x.report("hiredis") { hiredis.pipelined { |p| 100.times { p.call("GET", "key") } } }
+  x.report("ruby") { ruby.pipelined { |p| 100.times { p.call("GET", "key") } } }
+end
+
+benchmark("large string x 100") do |x|
+  x.report("hiredis") { hiredis.pipelined { |p| 100.times { p.call("GET", "large") } } }
+  x.report("ruby") { ruby.pipelined { |p| 100.times { p.call("GET", "large") } } }
+end
+
+benchmark("small list x 100") do |x|
+  x.report("hiredis") { hiredis.pipelined { |p| 100.times { p.call("LRANGE", "list", 0, -1) } } }
+  x.report("ruby") { ruby.pipelined { |p| 100.times { p.call("LRANGE", "list", 0, -1) } } }
+end
+
+benchmark("large list") do |x|
+  x.report("hiredis") { hiredis.call("LRANGE", "large-list", 0, -1) }
+  x.report("ruby") { ruby.call("LRANGE", "large-list", 0, -1) }
+end
+
+benchmark("small hash x 100") do |x|
+  x.report("hiredis") { hiredis.pipelined { |p| 100.times { p.call("HGETALL", "hash") } } }
+  x.report("ruby") { ruby.pipelined { |p| 100.times { p.call("HGETALL", "hash") } } }
+end
+
+benchmark("large hash") do |x|
+  x.report("hiredis") { ruby.call("HGETALL", "large-hash") }
+  x.report("ruby") { ruby.call("HGETALL", "large-hash") }
+end

--- a/benchmark/drivers_ruby.md
+++ b/benchmark/drivers_ruby.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     5402.4 i/s
-                ruby:     2877.9 i/s - 1.88x  slower
+             hiredis:     5416.0 i/s
+                ruby:     2923.7 i/s - 1.85x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:      297.2 i/s
-                ruby:      291.2 i/s - same-ish: difference falls within error
+             hiredis:      286.7 i/s
+                ruby:      302.3 i/s - same-ish: difference falls within error
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     2632.0 i/s
-                ruby:     1136.1 i/s - 2.32x  slower
+             hiredis:     2596.0 i/s
+                ruby:     1155.6 i/s - 2.25x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     6640.8 i/s
-                ruby:     1293.1 i/s - 5.14x  slower
+             hiredis:     6797.0 i/s
+                ruby:     1388.9 i/s - 4.89x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     3419.6 i/s
-                ruby:     1129.0 i/s - 3.03x  slower
+             hiredis:     3459.8 i/s
+                ruby:     1170.4 i/s - 2.96x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     1299.3 i/s
-                ruby:     1275.3 i/s - same-ish: difference falls within error
+             hiredis:     1345.9 i/s
+                ruby:     1329.5 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_ruby.md
+++ b/benchmark/drivers_ruby.md
@@ -1,0 +1,59 @@
+ruby: `ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]`
+
+redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`
+
+
+### small string x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
+             hiredis:     5402.4 i/s
+                ruby:     2877.9 i/s - 1.88x  slower
+
+```
+
+### large string x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
+             hiredis:      297.2 i/s
+                ruby:      291.2 i/s - same-ish: difference falls within error
+
+```
+
+### small list x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
+             hiredis:     2632.0 i/s
+                ruby:     1136.1 i/s - 2.32x  slower
+
+```
+
+### large list
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
+             hiredis:     6640.8 i/s
+                ruby:     1293.1 i/s - 5.14x  slower
+
+```
+
+### small hash x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
+             hiredis:     3419.6 i/s
+                ruby:     1129.0 i/s - 3.03x  slower
+
+```
+
+### large hash
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
+             hiredis:     1299.3 i/s
+                ruby:     1275.3 i/s - same-ish: difference falls within error
+
+```
+

--- a/benchmark/drivers_ruby.md
+++ b/benchmark/drivers_ruby.md
@@ -1,4 +1,4 @@
-ruby: `ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]`
+ruby: `ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]`
 
 redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`
 
@@ -6,54 +6,54 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 ### small string x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     5470.4 i/s
-                ruby:     3246.7 i/s - 1.68x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
+             hiredis:     4825.5 i/s
+                ruby:     2863.4 i/s - 1.69x  slower
 
 ```
 
 ### large string x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:      304.4 i/s
-                ruby:      230.2 i/s - 1.32x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
+             hiredis:      266.6 i/s
+                ruby:      198.1 i/s - 1.35x  slower
 
 ```
 
 ### small list x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     2643.4 i/s
-                ruby:     1312.4 i/s - 2.01x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
+             hiredis:     2416.9 i/s
+                ruby:     1223.3 i/s - 1.98x  slower
 
 ```
 
 ### large list
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     6761.3 i/s
-                ruby:     1796.0 i/s - 3.76x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
+             hiredis:     5351.6 i/s
+                ruby:     1718.0 i/s - 3.11x  slower
 
 ```
 
 ### small hash x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     3293.2 i/s
-                ruby:     1435.0 i/s - 2.29x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
+             hiredis:     2854.3 i/s
+                ruby:     1294.4 i/s - 2.21x  slower
 
 ```
 
 ### large hash
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     1765.3 i/s
-                ruby:     1782.7 i/s - same-ish: difference falls within error
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
+             hiredis:     1580.6 i/s
+                ruby:     1634.7 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_ruby.md
+++ b/benchmark/drivers_ruby.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     5416.0 i/s
-                ruby:     2923.7 i/s - 1.85x  slower
+             hiredis:     5346.6 i/s
+                ruby:     2984.3 i/s - 1.79x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:      286.7 i/s
-                ruby:      302.3 i/s - same-ish: difference falls within error
+             hiredis:      304.2 i/s
+                ruby:      204.1 i/s - 1.49x  slower
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     2596.0 i/s
-                ruby:     1155.6 i/s - 2.25x  slower
+             hiredis:     2612.0 i/s
+                ruby:     1240.8 i/s - 2.11x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     6797.0 i/s
-                ruby:     1388.9 i/s - 4.89x  slower
+             hiredis:     6772.7 i/s
+                ruby:     1540.7 i/s - 4.40x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     3459.8 i/s
-                ruby:     1170.4 i/s - 2.96x  slower
+             hiredis:     3293.2 i/s
+                ruby:     1234.0 i/s - 2.67x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     1345.9 i/s
-                ruby:     1329.5 i/s - same-ish: difference falls within error
+             hiredis:     1421.7 i/s
+                ruby:     1481.0 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_ruby.md
+++ b/benchmark/drivers_ruby.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     5346.6 i/s
-                ruby:     2984.3 i/s - 1.79x  slower
+             hiredis:     5369.2 i/s
+                ruby:     3095.8 i/s - 1.73x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:      304.2 i/s
-                ruby:      204.1 i/s - 1.49x  slower
+             hiredis:      303.9 i/s
+                ruby:      217.9 i/s - 1.39x  slower
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     2612.0 i/s
-                ruby:     1240.8 i/s - 2.11x  slower
+             hiredis:     2706.0 i/s
+                ruby:     1325.4 i/s - 2.04x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     6772.7 i/s
-                ruby:     1540.7 i/s - 4.40x  slower
+             hiredis:     6827.5 i/s
+                ruby:     1755.0 i/s - 3.89x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     3293.2 i/s
-                ruby:     1234.0 i/s - 2.67x  slower
+             hiredis:     3453.2 i/s
+                ruby:     1359.5 i/s - 2.54x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     1421.7 i/s
-                ruby:     1481.0 i/s - same-ish: difference falls within error
+             hiredis:     1655.5 i/s
+                ruby:     1666.5 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_ruby.md
+++ b/benchmark/drivers_ruby.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     5369.2 i/s
-                ruby:     3095.8 i/s - 1.73x  slower
+             hiredis:     5470.4 i/s
+                ruby:     3246.7 i/s - 1.68x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:      303.9 i/s
-                ruby:      217.9 i/s - 1.39x  slower
+             hiredis:      304.4 i/s
+                ruby:      230.2 i/s - 1.32x  slower
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     2706.0 i/s
-                ruby:     1325.4 i/s - 2.04x  slower
+             hiredis:     2643.4 i/s
+                ruby:     1312.4 i/s - 2.01x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     6827.5 i/s
-                ruby:     1755.0 i/s - 3.89x  slower
+             hiredis:     6761.3 i/s
+                ruby:     1796.0 i/s - 3.76x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     3453.2 i/s
-                ruby:     1359.5 i/s - 2.54x  slower
+             hiredis:     3293.2 i/s
+                ruby:     1435.0 i/s - 2.29x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
-             hiredis:     1655.5 i/s
-                ruby:     1666.5 i/s - same-ish: difference falls within error
+             hiredis:     1765.3 i/s
+                ruby:     1782.7 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_yjit.md
+++ b/benchmark/drivers_yjit.md
@@ -1,0 +1,59 @@
+ruby: `ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]`
+
+redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`
+
+
+### small string x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
+             hiredis:     6745.7 i/s
+                ruby:     5182.0 i/s - 1.30x  slower
+
+```
+
+### large string x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
+             hiredis:      303.5 i/s
+                ruby:      343.1 i/s - 1.13x  faster
+
+```
+
+### small list x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
+             hiredis:     3683.6 i/s
+                ruby:     1952.3 i/s - 1.89x  slower
+
+```
+
+### large list
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
+             hiredis:     6540.2 i/s
+                ruby:     2710.0 i/s - 2.41x  slower
+
+```
+
+### small hash x 100
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
+             hiredis:     4002.6 i/s
+                ruby:     2317.0 i/s - 1.73x  slower
+
+```
+
+### large hash
+
+```
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
+             hiredis:     2467.1 i/s
+                ruby:     2439.0 i/s - same-ish: difference falls within error
+
+```
+

--- a/benchmark/drivers_yjit.md
+++ b/benchmark/drivers_yjit.md
@@ -1,4 +1,4 @@
-ruby: `ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]`
+ruby: `ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]`
 
 redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`
 
@@ -6,54 +6,54 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 ### small string x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6810.9 i/s
-                ruby:     5613.1 i/s - 1.21x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
+             hiredis:     6407.8 i/s
+                ruby:     5852.0 i/s - same-ish: difference falls within error
 
 ```
 
 ### large string x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:      312.1 i/s
-                ruby:      316.3 i/s - same-ish: difference falls within error
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
+             hiredis:      302.8 i/s
+                ruby:      337.3 i/s - same-ish: difference falls within error
 
 ```
 
 ### small list x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3644.1 i/s
-                ruby:     2474.0 i/s - 1.47x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
+             hiredis:     4067.7 i/s
+                ruby:     2721.5 i/s - 1.49x  slower
 
 ```
 
 ### large list
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6884.4 i/s
-                ruby:     5473.2 i/s - 1.26x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
+             hiredis:     7138.7 i/s
+                ruby:     6605.4 i/s - same-ish: difference falls within error
 
 ```
 
 ### small hash x 100
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     4033.9 i/s
-                ruby:     3236.3 i/s - 1.25x  slower
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
+             hiredis:     4219.8 i/s
+                ruby:     3586.4 i/s - 1.18x  slower
 
 ```
 
 ### large hash
 
 ```
-ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     4753.7 i/s
-                ruby:     4637.7 i/s - same-ish: difference falls within error
+ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
+             hiredis:     5240.9 i/s
+                ruby:     5312.5 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_yjit.md
+++ b/benchmark/drivers_yjit.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6795.5 i/s
-                ruby:     5696.7 i/s - 1.19x  slower
+             hiredis:     6810.9 i/s
+                ruby:     5613.1 i/s - 1.21x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:      291.0 i/s
-                ruby:      339.3 i/s - same-ish: difference falls within error
+             hiredis:      312.1 i/s
+                ruby:      316.3 i/s - same-ish: difference falls within error
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3661.1 i/s
-                ruby:     2351.8 i/s - 1.56x  slower
+             hiredis:     3644.1 i/s
+                ruby:     2474.0 i/s - 1.47x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6839.3 i/s
-                ruby:     5330.8 i/s - 1.28x  slower
+             hiredis:     6884.4 i/s
+                ruby:     5473.2 i/s - 1.26x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3966.9 i/s
-                ruby:     3243.4 i/s - 1.22x  slower
+             hiredis:     4033.9 i/s
+                ruby:     3236.3 i/s - 1.25x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     4609.7 i/s
-                ruby:     4612.8 i/s - same-ish: difference falls within error
+             hiredis:     4753.7 i/s
+                ruby:     4637.7 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_yjit.md
+++ b/benchmark/drivers_yjit.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6745.7 i/s
-                ruby:     5182.0 i/s - 1.30x  slower
+             hiredis:     6775.6 i/s
+                ruby:     5212.3 i/s - 1.30x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:      303.5 i/s
-                ruby:      343.1 i/s - 1.13x  faster
+             hiredis:      306.1 i/s
+                ruby:      335.5 i/s - same-ish: difference falls within error
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3683.6 i/s
-                ruby:     1952.3 i/s - 1.89x  slower
+             hiredis:     3566.7 i/s
+                ruby:     1999.6 i/s - 1.78x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6540.2 i/s
-                ruby:     2710.0 i/s - 2.41x  slower
+             hiredis:     6563.1 i/s
+                ruby:     2984.7 i/s - 2.20x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     4002.6 i/s
-                ruby:     2317.0 i/s - 1.73x  slower
+             hiredis:     3870.9 i/s
+                ruby:     2387.4 i/s - 1.62x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     2467.1 i/s
-                ruby:     2439.0 i/s - same-ish: difference falls within error
+             hiredis:     2641.9 i/s
+                ruby:     2575.8 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_yjit.md
+++ b/benchmark/drivers_yjit.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6775.6 i/s
-                ruby:     5212.3 i/s - 1.30x  slower
+             hiredis:     6723.1 i/s
+                ruby:     5507.5 i/s - 1.22x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:      306.1 i/s
-                ruby:      335.5 i/s - same-ish: difference falls within error
+             hiredis:      290.8 i/s
+                ruby:      335.2 i/s - same-ish: difference falls within error
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3566.7 i/s
-                ruby:     1999.6 i/s - 1.78x  slower
+             hiredis:     3686.7 i/s
+                ruby:     2437.1 i/s - 1.51x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6563.1 i/s
-                ruby:     2984.7 i/s - 2.20x  slower
+             hiredis:     6725.9 i/s
+                ruby:     4990.0 i/s - 1.35x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3870.9 i/s
-                ruby:     2387.4 i/s - 1.62x  slower
+             hiredis:     3893.0 i/s
+                ruby:     2994.7 i/s - 1.30x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     2641.9 i/s
-                ruby:     2575.8 i/s - same-ish: difference falls within error
+             hiredis:     4303.3 i/s
+                ruby:     4244.6 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_yjit.md
+++ b/benchmark/drivers_yjit.md
@@ -7,8 +7,8 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6723.1 i/s
-                ruby:     5507.5 i/s - 1.22x  slower
+             hiredis:     6795.5 i/s
+                ruby:     5696.7 i/s - 1.19x  slower
 
 ```
 
@@ -16,8 +16,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:      290.8 i/s
-                ruby:      335.2 i/s - same-ish: difference falls within error
+             hiredis:      291.0 i/s
+                ruby:      339.3 i/s - same-ish: difference falls within error
 
 ```
 
@@ -25,8 +25,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3686.7 i/s
-                ruby:     2437.1 i/s - 1.51x  slower
+             hiredis:     3661.1 i/s
+                ruby:     2351.8 i/s - 1.56x  slower
 
 ```
 
@@ -34,8 +34,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     6725.9 i/s
-                ruby:     4990.0 i/s - 1.35x  slower
+             hiredis:     6839.3 i/s
+                ruby:     5330.8 i/s - 1.28x  slower
 
 ```
 
@@ -43,8 +43,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     3893.0 i/s
-                ruby:     2994.7 i/s - 1.30x  slower
+             hiredis:     3966.9 i/s
+                ruby:     3243.4 i/s - 1.22x  slower
 
 ```
 
@@ -52,8 +52,8 @@ ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
 
 ```
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
-             hiredis:     4303.3 i/s
-                ruby:     4244.6 i/s - same-ish: difference falls within error
+             hiredis:     4609.7 i/s
+                ruby:     4612.8 i/s - same-ish: difference falls within error
 
 ```
 

--- a/lib/redis_client/ruby_connection/buffered_io.rb
+++ b/lib/redis_client/ruby_connection/buffered_io.rb
@@ -82,8 +82,10 @@ class RedisClient
       end
 
       def getbyte
-        ensure_remaining(1)
-        byte = @buffer.getbyte(@offset)
+        unless byte = @buffer.getbyte(@offset)
+          ensure_remaining(1)
+          byte = @buffer.getbyte(@offset)
+        end
         @offset += 1
         byte
       end

--- a/lib/redis_client/ruby_connection/buffered_io.rb
+++ b/lib/redis_client/ruby_connection/buffered_io.rb
@@ -12,7 +12,7 @@ class RedisClient
 
       def initialize(io, read_timeout:, write_timeout:, chunk_size: 4096)
         @io = io
-        @buffer = "".b
+        @buffer = "".dup.force_encoding(Encoding.default_external)
         @offset = 0
         @chunk_size = chunk_size
         @read_timeout = read_timeout

--- a/lib/redis_client/ruby_connection/resp3.rb
+++ b/lib/redis_client/ruby_connection/resp3.rb
@@ -144,7 +144,6 @@ class RedisClient
 
     def parse_string(io)
       str = io.gets_chomp
-      str.force_encoding(Encoding.default_external)
       str.force_encoding(Encoding::BINARY) unless str.valid_encoding?
       str.freeze
     end
@@ -221,7 +220,6 @@ class RedisClient
       return if bytesize < 0 # RESP2 nil type
 
       str = io.read_chomp(bytesize)
-      str.force_encoding(Encoding.default_external)
       str.force_encoding(Encoding::BINARY) unless str.valid_encoding?
       str
     end

--- a/lib/redis_client/ruby_connection/resp3.rb
+++ b/lib/redis_client/ruby_connection/resp3.rb
@@ -111,10 +111,35 @@ class RedisClient
 
     def parse(io)
       type = io.getbyte
-      method = PARSER_TYPES.fetch(type) do
+      if type == 35 # '#'.ord
+        parse_boolean(io)
+      elsif type == 36 # '$'.ord
+        parse_blob(io)
+      elsif type == 43 # '+'.ord
+        parse_string(io)
+      elsif type == 61 # '='.ord
+        parse_verbatim_string(io)
+      elsif type == 45 # '-'.ord
+        parse_error(io)
+      elsif type == 58 # ':'.ord
+        parse_integer(io)
+      elsif type == 40 # '('.ord
+        parse_integer(io)
+      elsif type == 44 # ','.ord
+        parse_double(io)
+      elsif type == 95 # '_'.ord
+        parse_null(io)
+      elsif type == 42 # '*'.ord
+        parse_array(io)
+      elsif type == 37 # '%'.ord
+        parse_map(io)
+      elsif type == 126 # '~'.ord
+        parse_set(io)
+      elsif type == 62 # '>'.ord
+        parse_array(io)
+      else
         raise UnknownType, "Unknown sigil type: #{type.chr.inspect}"
       end
-      send(method, io)
     end
 
     def parse_string(io)

--- a/lib/redis_client/ruby_connection/resp3.rb
+++ b/lib/redis_client/ruby_connection/resp3.rb
@@ -165,16 +165,16 @@ class RedisClient
     end
 
     def parse_array(io)
-      parse_sequence(io, parse_integer(io))
+      parse_sequence(io, io.gets_integer)
     end
 
     def parse_set(io)
-      parse_sequence(io, parse_integer(io))
+      parse_sequence(io, io.gets_integer)
     end
 
     def parse_map(io)
       hash = {}
-      parse_integer(io).times do
+      io.gets_integer.times do
         hash[parse(io)] = parse(io)
       end
       hash
@@ -217,7 +217,7 @@ class RedisClient
     end
 
     def parse_blob(io)
-      bytesize = parse_integer(io)
+      bytesize = io.gets_integer
       return if bytesize < 0 # RESP2 nil type
 
       str = io.read_chomp(bytesize)


### PR DESCRIPTION
I recently paired with @tenderlove on trying to see if the Ruby vs Hiredis performance difference could be closed.

We came up with a bunch of small changes that really close the gap quite significantly, especially when YJIT is enabled.

The Ruby driver is now either on par with hiredis, or just marginally slower on some cases.

There are a few more optimization we thought of, but they require some changes in Ruby, I'll try to work on these this year. Notably a way to create hashes with a given capacity would help a lot.

## Before (YJIT)

ruby: `ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]`

redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`


### small string x 100

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
             hiredis:     6745.7 i/s
                ruby:     5182.0 i/s - 1.30x  slower

```

### large string x 100

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
             hiredis:      303.5 i/s
                ruby:      343.1 i/s - 1.13x  faster

```

### small list x 100

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
             hiredis:     3683.6 i/s
                ruby:     1952.3 i/s - 1.89x  slower

```

### large list

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
             hiredis:     6540.2 i/s
                ruby:     2710.0 i/s - 2.41x  slower

```

### small hash x 100

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
             hiredis:     4002.6 i/s
                ruby:     2317.0 i/s - 1.73x  slower

```

### large hash

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
             hiredis:     2467.1 i/s
                ruby:     2439.0 i/s - same-ish: difference falls within error

```

## After (YJIT)

ruby: `ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]`

redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`


### small string x 100

```
ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
             hiredis:     6407.8 i/s
                ruby:     5852.0 i/s - same-ish: difference falls within error

```

### large string x 100

```
ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
             hiredis:      302.8 i/s
                ruby:      337.3 i/s - same-ish: difference falls within error

```

### small list x 100

```
ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
             hiredis:     4067.7 i/s
                ruby:     2721.5 i/s - 1.49x  slower

```

### large list

```
ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
             hiredis:     7138.7 i/s
                ruby:     6605.4 i/s - same-ish: difference falls within error

```

### small hash x 100

```
ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
             hiredis:     4219.8 i/s
                ruby:     3586.4 i/s - 1.18x  slower

```

### large hash

```
ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
             hiredis:     5240.9 i/s
                ruby:     5312.5 i/s - same-ish: difference falls within error

```

NB: the later use `ruby-head` to benefit from some YJIT opts.
