### PR TITLE
Better detection of Windows platform

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -8,7 +8,7 @@ class HiredisConnectionExtconf
   end
 
   def configure
-    if RUBY_ENGINE == "ruby" && !RUBY_PLATFORM.match?(/mswin/)
+    if RUBY_ENGINE == "ruby" && !Gem.win_platform?
       configure_extension
       create_makefile("redis_client/hiredis_connection")
     else


### PR DESCRIPTION
The existing check for the Windows platform doesn't always work. For example `mingw` is not checked.

See https://github.com/OpenC3/cosmos/issues/1170