### PR TITLE
add flag to disable raising exceptions with pipelined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Made various performance optimizations to the Ruby driver. See #184.
 - Always assume UTF-8 encoding instead of relying on `Encoding.default_external`.
+- Add `exception` flag in `pipelined` allowing failed commands to be returned in the result array when set to `false`. See #187.
 
 # 0.21.1
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,27 @@ end
 # => ["OK", 1]
 ```
 
+#### Exception management
+
+The `exception` flag in the `#pipelined` method of `RedisClient` is a feature that modifies the pipeline execution
+behavior. When set to `false`, it doesn't raise an exception when a command error occurs. Instead, it allows the
+pipeline to execute all commands, and any failed command will be available in the returned array. (Defaults to `true`)
+
+```ruby
+results = redis.pipelined(exception: false) do |pipeline|
+  pipeline.call("SET", "foo", "bar") # => nil
+  pipeline.call("DOESNOTEXIST", 12) # => nil
+  pipeline.call("INCR", "baz") # => nil
+end
+# results => ["OK", #<RedisClient::CommandError: ERR unknown command 'DOESNOTEXIST', with args beginning with: '12'>, 2]
+
+results.each do |result|
+  if result.is_a?(RedisClient::CommandError)
+    # Do something with the failed result
+  end
+end
+```
+
 ### Transactions
 
 You can use [`MULTI/EXEC` to run a number of commands in an atomic fashion](https://redis.io/topics/transactions).

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -421,7 +421,7 @@ class RedisClient
     ensure_connected(retryable: false, &block)
   end
 
-  def pipelined
+  def pipelined(exception: true)
     pipeline = Pipeline.new(@command_builder)
     yield pipeline
 
@@ -431,7 +431,7 @@ class RedisClient
       results = ensure_connected(retryable: pipeline._retryable?) do |connection|
         commands = pipeline._commands
         @middlewares.call_pipelined(commands, config) do
-          connection.call_pipelined(commands, pipeline._timeouts)
+          connection.call_pipelined(commands, pipeline._timeouts, exception: exception)
         end
       end
 

--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -39,8 +39,8 @@ class RedisClient
       end
     end
 
-    def call_pipelined(commands, timeouts)
-      exception = nil
+    def call_pipelined(commands, timeouts, exception: true)
+      first_exception = nil
 
       size = commands.size
       results = Array.new(commands.size)
@@ -61,14 +61,14 @@ class RedisClient
         elsif result.is_a?(Error)
           result._set_command(commands[index])
           result._set_config(config)
-          exception ||= result
+          first_exception ||= result
         end
 
         results[index] = result
       end
 
-      if exception
-        raise exception
+      if first_exception && exception
+        raise first_exception
       else
         results
       end

--- a/lib/redis_client/decorator.rb
+++ b/lib/redis_client/decorator.rb
@@ -47,8 +47,8 @@ class RedisClient
       end
       ruby2_keywords :with if respond_to?(:ruby2_keywords, true)
 
-      def pipelined
-        @client.pipelined { |p| yield @_pipeline_class.new(p) }
+      def pipelined(exception: true)
+        @client.pipelined(exception: exception) { |p| yield @_pipeline_class.new(p) }
       end
 
       def multi(**kwargs)


### PR DESCRIPTION
Modifying the `pipelined` method in `lib/redis_client.rb` to include an optional `exception` parameter, which determines whether an exception should be raised when an error occurs during pipelining.

This gives better flexibility for error management when we want to retry only failed commands.