### PR TITLE
Fix BufferedIO to search with `byteindex`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -208,3 +208,6 @@ Style/CaseLikeIf:
 
 Style/EmptyMethod:
   Enabled: false
+
+Style/AccessModifierDeclarations:
+  Enabled: false

--- a/test/redis_client/resp3_test.rb
+++ b/test/redis_client/resp3_test.rb
@@ -108,6 +108,11 @@ class RedisClient
       assert_parses [1, 2, 3], "*3\r\n:1\r\n:2\r\n:3\r\n"
     end
 
+    def test_load_multibyte_chars
+      # Check that the buffer is properly operating over bytes and not characters
+      assert_parses ["€™€™", 2], "*2\r\n$12\r\n€™€™\r\n:2\r\n"
+    end
+
     def test_load_set
       assert_parses ['orange', 'apple', true, 100, 999], "~5\r\n+orange\r\n+apple\r\n#t\r\n:100\r\n:999\r\n"
     end


### PR DESCRIPTION
As of https://github.com/redis-rb/redis-client/pull/184, the buffer String is no longer BINARY but UTF-8.

I missed that the code that search for newlines was using `.index` instead of `.byteindex`, causing the buffer offset to go out of sync.
