### PR TITLE
BufferedIO#gets_integer: remove optimistic EOL optimization

### DIFF
--- a/benchmark/drivers_ruby.md
+++ b/benchmark/drivers_ruby.md
@@ -1,4 +1,4 @@
-ruby: `ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]`
+ruby: `ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]`
 
 redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`
 
@@ -6,54 +6,54 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 ### small string x 100
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
-             hiredis:     5239.0 i/s
-                ruby:     2957.4 i/s - 1.77x  slower
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]
+             hiredis:     5085.0 i/s
+                ruby:     2922.4 i/s - 1.74x  slower
 
 ```
 
 ### large string
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
-             hiredis:    12784.9 i/s
-                ruby:    14948.2 i/s - same-ish: difference falls within error
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]
+             hiredis:    10287.9 i/s
+                ruby:    12928.2 i/s - 1.26x  faster
 
 ```
 
 ### small list x 100
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
-             hiredis:     2599.3 i/s
-                ruby:     1300.0 i/s - 2.00x  slower
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]
+             hiredis:     2534.8 i/s
+                ruby:     1145.9 i/s - 2.21x  slower
 
 ```
 
 ### large list
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
-             hiredis:     6836.0 i/s
-                ruby:     1867.6 i/s - 3.66x  slower
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]
+             hiredis:     5904.5 i/s
+                ruby:     1508.8 i/s - 3.91x  slower
 
 ```
 
 ### small hash x 100
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
-             hiredis:     3392.5 i/s
-                ruby:     1408.9 i/s - 2.41x  slower
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]
+             hiredis:     2993.3 i/s
+                ruby:     1179.7 i/s - 2.54x  slower
 
 ```
 
 ### large hash
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]
-             hiredis:     1786.2 i/s
-                ruby:     1811.9 i/s - same-ish: difference falls within error
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]
+             hiredis:     1473.2 i/s
+                ruby:     1460.3 i/s - same-ish: difference falls within error
 
 ```
 

--- a/benchmark/drivers_yjit.md
+++ b/benchmark/drivers_yjit.md
@@ -1,4 +1,4 @@
-ruby: `ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) [arm64-darwin23]`
+ruby: `ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) [arm64-darwin23]`
 
 redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a11d0151eabf466c`
 
@@ -6,54 +6,54 @@ redis-server: `Redis server v=7.0.12 sha=00000000:0 malloc=libc bits=64 build=a1
 ### small string x 100
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
-             hiredis:     7148.9 i/s
-                ruby:     5758.6 i/s - 1.24x  slower
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) +YJIT [arm64-darwin23]
+             hiredis:     6374.1 i/s
+                ruby:     5179.1 i/s - 1.23x  slower
 
 ```
 
 ### large string
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
-             hiredis:    13023.5 i/s
-                ruby:    20246.4 i/s - 1.55x  faster
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) +YJIT [arm64-darwin23]
+             hiredis:     9048.4 i/s
+                ruby:    16196.0 i/s - 1.79x  faster
 
 ```
 
 ### small list x 100
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
-             hiredis:     3973.6 i/s
-                ruby:     2668.7 i/s - 1.49x  slower
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) +YJIT [arm64-darwin23]
+             hiredis:     3589.3 i/s
+                ruby:     2314.0 i/s - 1.55x  slower
 
 ```
 
 ### large list
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
-             hiredis:     6706.8 i/s
-                ruby:     6529.3 i/s - same-ish: difference falls within error
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) +YJIT [arm64-darwin23]
+             hiredis:     6176.7 i/s
+                ruby:     5471.0 i/s - same-ish: difference falls within error
 
 ```
 
 ### small hash x 100
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
-             hiredis:     4001.6 i/s
-                ruby:     3482.9 i/s - 1.15x  slower
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) +YJIT [arm64-darwin23]
+             hiredis:     3692.9 i/s
+                ruby:     3087.0 i/s - same-ish: difference falls within error
 
 ```
 
 ### large hash
 
 ```
-ruby 3.4.0dev (2024-03-19T14:18:56Z master 5c2937733c) +YJIT [arm64-darwin23]
-             hiredis:     5511.9 i/s
-                ruby:     5555.7 i/s - same-ish: difference falls within error
+ruby 3.4.0dev (2024-03-26T11:54:54Z master 2b08406cd0) +YJIT [arm64-darwin23]
+             hiredis:     4640.6 i/s
+                ruby:     4741.6 i/s - same-ish: difference falls within error
 
 ```
 

--- a/lib/redis_client/ruby_connection/buffered_io.rb
+++ b/lib/redis_client/ruby_connection/buffered_io.rb
@@ -162,18 +162,17 @@ class RedisClient
         while true
           chr = @buffer.getbyte(offset)
 
-          if chr
-            if chr == 13 # "\r".ord
-              @offset = offset + 2
-              break
-            else
-              int = (int * 10) + chr - 48
-            end
-            offset += 1
-          else
+          if chr.nil? # end of buffer
             ensure_line
             return gets_integer
+          elsif chr == 13 # "\r".ord
+            @offset = offset
+            skip(2)
+            break
+          else
+            int = (int * 10) + chr - 48
           end
+          offset += 1
         end
 
         int


### PR DESCRIPTION
Tentative fix for https://github.com/redis-rb/redis-client/issues/190

I wasn't able to reproduce, not to really figure out the root cause.

`Unknown sigil type: "\r"` suggest we corrupted the offset after calling `gets_integer`. When we read `\r` we assume `\n` is next but don't check if we read it yet, and just increment the offset, and the offset can potentially be past the buffer.

I don't know how it happens exactly, but somehow we sometimes don't handle this case properly.

The fact that it was reported with a `pubsub` use case suggest it might be after a read timeout, but can't be certain.