### PR TITLE
fix(config): server_url should return a valid URI for IPv6 hosts

### DIFF
--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -133,7 +133,13 @@ class RedisClient
             url = "#{url}?db=#{db}"
           end
         else
-          url = "redis#{'s' if ssl?}://#{host}:#{port}"
+          # add brackets to IPv6 address
+          redis_host = if host.count(":") >= 2
+            "[#{host}]"
+          else
+            host
+          end
+          url = "redis#{'s' if ssl?}://#{redis_host}:#{port}"
           if db != 0
             url = "#{url}/#{db}"
           end

--- a/test/redis_client/config_test.rb
+++ b/test/redis_client/config_test.rb
@@ -201,8 +201,15 @@ class RedisClient
       assert_equal "redis://localhost:6379", Config.new.server_url
       assert_equal "redis://localhost:6379", Config.new(username: "george", password: "hunter2").server_url
       assert_equal "redis://localhost:6379/5", Config.new(db: 5).server_url
+      assert_equal "redis://192.168.0.1:6379", Config.new(host: "192.168.0.1", port: 6379).server_url
+      assert_equal "redis://192.168.0.1:6379/5", Config.new(host: "192.168.0.1", port: 6379, db: 5).server_url
       assert_equal "redis://example.com:8080", Config.new(host: "example.com", port: 8080).server_url
       assert_equal "rediss://localhost:6379", Config.new(ssl: true).server_url
+      assert_equal "redis://[::1]:6379", Config.new(host: "::1", port: 6379).server_url
+      assert_equal "redis://[::1]:6379/2", Config.new(host: "::1", port: 6379, db: 2).server_url
+      assert_equal "redis://[::1]:6379/2", Config.new(url: "redis://[::1]:6379/2").server_url
+      assert_equal "redis://[ffff:aaaa:1111::fcf]:6379", Config.new(host: "ffff:aaaa:1111::fcf", port: 6379).server_url
+      assert_equal "redis://[ffff:aaaa:1111::fcf]:6379/2", Config.new(host: "ffff:aaaa:1111::fcf", port: 6379, db: 2).server_url
 
       assert_equal "unix:///var/redis/redis.sock?db=5", Config.new(path: "/var/redis/redis.sock", db: 5).server_url
     end


### PR DESCRIPTION
[Datadog's ddtrace-rb](https://github.com/DataDog/dd-trace-rb) relies on the `RedisClient::Config#server_url` to return a valid `redis://` address as part of initializing its tracing middleware. 

https://github.com/DataDog/dd-trace-rb/blob/master/lib/datadog/tracing/contrib/redis/trace_middleware.rb#L79

With an IPv6 redis instance, sidekiq 7.2 would not start up due to `bad URI(is not URI?): "redis://fd1b:ac4a:ab80::fcf:6379/12"`which URI fails to parse properly.

This PR makes it so we try to detect an IPv6 address in the `host` and return a valid `redis://` address in that particular case. 