### PR TITLE
Ensure BLPOP/BRPOP returns nil instead of raising ReadTimeoutError

### DIFF
--- a/test/shared/redis_client_tests.rb
+++ b/test/shared/redis_client_tests.rb
@@ -448,12 +448,30 @@ module RedisClientTests
     assert_equal "OK", @redis.call("SET", "foo", "bar")
   end
 
-  def test_blocking_call_timeout_retries
-    redis = new_client(reconnect_attempts: [3.0])
-    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    assert_raises RedisClient::ReadTimeoutError do
-      redis.blocking_call(0.1, "BRPOP", "list", "0.1")
+  def test_blocking_call_long_timeout
+    client = new_client(timeout: 0.5)
+    assert_nil client.blocking_call(0.5, "BRPOP", "list", "0.5")
+    assert_nil client.blocking_call_v(0.5, ["BRPOP", "list", "0.5"])
+
+    result = client.pipelined do |pipeline|
+      pipeline.blocking_call(0.5, "BRPOP", "list", "0.5")
+      pipeline.blocking_call_v(0.5, ["BRPOP", "list", "0.5"])
     end
+
+    assert_equal([nil, nil], result)
+
+    result = client.multi do |pipeline|
+      pipeline.call("BRPOP", "list", "0.5")
+      pipeline.call_v(["BRPOP", "list", "0.5"])
+    end
+
+    assert_equal([nil, nil], result)
+  end
+
+  def test_blocking_call_timeout_retries
+    redis = new_client(timeout: 0.5, reconnect_attempts: [3.0])
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    assert_nil redis.blocking_call(0.1, "BRPOP", "list", "0.1")
     duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
     assert duration < 0.5 # if we retried we'd have waited much long
   end


### PR DESCRIPTION
In https://github.com/redis/redis-rb/issues/1279, we discovered that when using BLPOP or BRPOP `redis-rb` properly returned `nil` when `timeout` was reached with no key present, but when connecting to Redis Sentinels, the client raised a `ReadTimeoutTimeout` error.

This occurred because of a subtle difference in how `RedisClient` (from `redis-rb`) and `Redis::Client` (from `redis-client`) behaved. The former, which is used with standalone Redis, returned `nil` because the socket read timeout was incremented to the command timeout value (https://github.com/redis/redis-rb/pull/1175). The latter did not have this, so the socket read timeout would get triggered before the actual Redis timeout hit.

To make the behavior consistent, increment the configured read timeout to the command timeout. 

Closes https://github.com/redis/redis-rb/issues/1279