### PR TITLE
Update the link URL to Redis Sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ redis.call("GET", "mykey")
 
 ### Sentinel support
 
-The client is able to perform automatic failover by using [Redis Sentinel](https://redis.io/docs/manual/sentinel/).
+The client is able to perform automatic failover by using [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/).
 
 To connect using Sentinel, use:
 


### PR DESCRIPTION
A new doccument about Redis Sentinel seems on https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/. The current URL redirects to https://redis.io/docs/latest/. 