### PR TITLE
Remove unused files from the gem package

### DIFF
--- a/hiredis-client/hiredis-client.gemspec
+++ b/hiredis-client/hiredis-client.gemspec
@@ -21,9 +21,10 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  gemspec = File.basename(__FILE__)
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features|benchmark)/|\.(?:git|rubocop))})
+      (f == gemspec) || f.start_with?(*%w[bin/ test/])
     end
   end
   spec.require_paths = ["lib"]

--- a/redis-client.gemspec
+++ b/redis-client.gemspec
@@ -21,9 +21,10 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  gemspec = File.basename(__FILE__)
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|hiredis-client|test|spec|features|benchmark)/|\.(?:git|rubocop))})
+      (f == gemspec) || f.start_with?(*%w[bin/ hiredis-client/ test/ benchmark/ .git .rubocop Gemfile Rakefile])
     end
   end
   spec.require_paths = ["lib"]


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Security scans can get caught up with the contents of the `Gemfile.lock` even though it is given no heed.

Let's remove these files:

```diff
  CHANGELOG.md
- Gemfile
- Gemfile.lock
  LICENSE.md
  README.md
- Rakefile
  lib/redis-client.rb
  lib/redis_client.rb
  lib/redis_client/circuit_breaker.rb
  lib/redis_client/command_builder.rb
  lib/redis_client/config.rb
  lib/redis_client/connection_mixin.rb
  lib/redis_client/decorator.rb
  lib/redis_client/middlewares.rb
  lib/redis_client/pid_cache.rb
  lib/redis_client/pooled.rb
  lib/redis_client/ruby_connection.rb
  lib/redis_client/ruby_connection/buffered_io.rb
  lib/redis_client/ruby_connection/resp3.rb
  lib/redis_client/sentinel_config.rb
  lib/redis_client/url_config.rb
  lib/redis_client/version.rb
- redis-client.gemspec
```