### PR TITLE
Update rubocop dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,22 +13,22 @@ GEM
     connection_pool (2.4.1)
     hiredis (0.6.3)
     hiredis (0.6.3-java)
-    json (2.7.1)
-    json (2.7.1-java)
+    json (2.7.2)
+    json (2.7.2-java)
     megatest (0.2.0)
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
-    racc (1.7.3)
-    racc (1.7.3-java)
+    racc (1.8.1)
+    racc (1.8.1-java)
     rainbow (3.1.1)
     rake (13.2.1)
     rake-compiler (1.2.8)
       rake
     redis (4.6.0)
-    regexp_parser (2.9.0)
-    rexml (3.2.6)
+    regexp_parser (2.9.2)
+    rexml (3.3.8)
     rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -46,7 +46,7 @@ GEM
     ruby-progressbar (1.13.0)
     stackprof (0.2.26)
     toxiproxy (2.0.2)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,11 +13,11 @@ GEM
     connection_pool (2.4.1)
     hiredis (0.6.3)
     hiredis (0.6.3-java)
-    json (2.7.2)
-    json (2.7.2-java)
+    json (2.7.6)
+    json (2.7.6-java)
     megatest (0.2.0)
     parallel (1.24.0)
-    parser (3.3.5.0)
+    parser (3.3.5.1)
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
@@ -28,7 +28,7 @@ GEM
       rake
     redis (4.6.0)
     regexp_parser (2.9.2)
-    rexml (3.3.8)
+    rexml (3.3.9)
     rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)


### PR DESCRIPTION
Upgrades RuboCop dependencies which solves following issues with `rexml`:
https://nvd.nist.gov/vuln/detail/CVE-2024-41123
https://nvd.nist.gov/vuln/detail/CVE-2024-41946
