### PR TITLE
Allocate hiredis_reader_state_t inside hiredis_connection_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix a potential crash in `hiredis-client` when using subcriptions (`next_event`). See #221.
+
 # 0.23.0
 
 - Allow `password` to be a callable. Makes it easy to implement short lived password authentication strategies.

--- a/test/redis_client/subscriptions_test.rb
+++ b/test/redis_client/subscriptions_test.rb
@@ -89,5 +89,18 @@ class RedisClient
         refute_nil @redis.pubsub
       end
     end
+
+    def test_pubsub_timeout_retry
+      assert_nil @subscription.call("SUBSCRIBE", "mychannel")
+      refute_nil @subscription.next_event # subscribed event
+
+      assert_nil @subscription.next_event(0.01)
+      @redis.call("PUBLISH", "mychannel", "test")
+      1.times.each do # rubocop:disable Lint/UselessTimes
+        # We use 1.times.each to change the stack depth.
+        # See https://github.com/redis-rb/redis-client/issues/221
+        refute_nil @subscription.next_event
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/221

Avoid that pointer becoming invalid when YJIT kicks in.

