### PR TITLE
Fix retry logic not to attempt to retry on an open circuit breaker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix retry logic not to attempt to retry on an open circuit breaker. Fix #227.
+
 # 0.23.1
 
 - Fix a potential crash in `hiredis-client` when using subcriptions (`next_event`). See #221.

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -710,8 +710,13 @@ class RedisClient
         end
       rescue ConnectionError, ProtocolError => error
         preferred_error ||= error
-        preferred_error = error unless error.is_a?(CircuitBreaker::OpenCircuitError)
         close
+
+        if error.is_a?(CircuitBreaker::OpenCircuitError)
+          raise preferred_error
+        else
+          preferred_error = error
+        end
 
         if !@disable_reconnection && config.retry_connecting?(tries, error)
           tries += 1


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/227