### PR TITLE
Always wrap passwords in Proc so they're not exposed through `inspect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Allow `sentinel_password` to be provided as a `Proc`.
+- Ensure `Config#inspect` and `Config#to_s` do not display stored passwords.
+
 # 0.23.2
 
 - Fix retry logic not to attempt to retry on an open circuit breaker. Fix #227.

--- a/lib/redis_client/sentinel_config.rb
+++ b/lib/redis_client/sentinel_config.rb
@@ -38,9 +38,14 @@ class RedisClient
       end
 
       @to_list_of_hash = @to_hash = nil
+      password = if sentinel_password && !sentinel_password.respond_to?(:call)
+        ->(_) { sentinel_password }
+      else
+        sentinel_password
+      end
       @extra_config = {
         username: sentinel_username,
-        password: sentinel_password,
+        password: password,
         db: nil,
       }
       if client_config[:protocol] == 2

--- a/test/redis_client/config_test.rb
+++ b/test/redis_client/config_test.rb
@@ -86,6 +86,18 @@ class RedisClient
       assert_equal [%w[HELLO 3 AUTH username password]], config.connection_prelude
     end
 
+    def test_hide_password
+      config = Config.new(password: "PASSWORD")
+      refute_match "PASSWORD", config.inspect
+      refute_match "PASSWORD", config.to_s
+    end
+
+    def test_hide_password_in_uri
+      config = Config.new(url: "redis://username:PASSWORD@example.com")
+      refute_match "PASSWORD", config.inspect
+      refute_match "PASSWORD", config.to_s
+    end
+
     def test_resp2_frozen_prelude
       config = Config.new(protocol: 2, url: "redis://username:password@example.com")
       prelude = config.connection_prelude

--- a/test/sentinel/sentinel_test.rb
+++ b/test/sentinel/sentinel_test.rb
@@ -257,6 +257,12 @@ class RedisClient
       assert_equal 1, sentinel_client_mock.close_count
     end
 
+    def test_hide_sentinel_password
+      config = new_config(sentinel_password: "PASSWORD")
+      refute_match "PASSWORD", config.inspect
+      refute_match "PASSWORD", config.to_s
+    end
+
     def test_config_user_password_from_url_for_redis_master_replica_only
       config = new_config(url: "redis://george:hunter2@cache/10", name: nil)
       assert_equal "hunter2", config.password


### PR DESCRIPTION
Followup: https://github.com/redis/redis-rb/issues/1299

Also applies to sentinel passwords.

FYI: @mperham