### PR TITLE
Fix compilation in directories containing spaces

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/extconf.rb
+++ b/hiredis-client/ext/redis_client/hiredis/extconf.rb
@@ -21,7 +21,7 @@ class HiredisConnectionExtconf
 
     have_func("rb_hash_new_capa", "ruby.h")
 
-    $CFLAGS = concat_flags($CFLAGS, "-I#{hiredis_dir}", "-std=c99", "-fvisibility=hidden")
+    $CFLAGS = concat_flags($CFLAGS, "-I#{Shellwords.escape(hiredis_dir)}", "-std=c99", "-fvisibility=hidden")
     $CFLAGS = if @debug
       concat_flags($CFLAGS, "-Werror", "-g", RbConfig::CONFIG["debugflags"])
     else
@@ -53,7 +53,8 @@ class HiredisConnectionExtconf
     end
 
     $LDFLAGS = concat_flags($LDFLAGS, "-lssl", "-lcrypto")
-    $libs = concat_flags($libs, "#{hiredis_dir}/libhiredis.a", "#{hiredis_dir}/libhiredis_ssl.a")
+    $libs = concat_flags($libs, "#{Shellwords.escape(hiredis_dir)}/libhiredis.a",
+      "#{Shellwords.escape(hiredis_dir)}/libhiredis_ssl.a",)
   end
 
   def configure_openssl(original_env)


### PR DESCRIPTION
This fixes compilation failure when installing `hiredis-client` to a path with spaces.

To reproduce the error and verify the fix, run:

```
gem install -i ./\ tmp ./hiredis-client-0.24.0.gem
```