### PR TITLE
Fix `hiredis-client` compilation with `clang 21`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix `hiredis-client` compilation with `clang 21`.
+
 # 0.25.2
 
 - Fix circuit breakers to respect the `error_threshold_timeout` config is provided.

--- a/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
+++ b/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
@@ -36,9 +36,9 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <stdbool.h>
-#include "hiredis.h"
-#include "net.h"
-#include "hiredis_ssl.h"
+#include "vendor/hiredis.h"
+#include "vendor/net.h"
+#include "vendor/hiredis_ssl.h"
 #include <poll.h>
 
 #if !defined(RUBY_ASSERT)


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/250

cc @beauraF, I managed to reproduce and fix it on my machine, but I'd appreciate if you could give this a double check by trying it as a git gem.
