### PR TITLE
Fix `db: nil` having precedence over db in URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Unreleased
 
+- Fix precedence of `db: nil` initialization parameter.
+
+  ```ruby
+  Redis.new(url: "redis://localhost:6379/3", db: nil).db
+  ```
+
+  Before: `0`
+  After: `3`
+
 # 0.25.3
 
 - Fix `hiredis-client` compilation with `clang 21`.

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -191,14 +191,15 @@ class RedisClient
       path: nil,
       username: nil,
       password: nil,
+      db: nil,
       **kwargs
     )
       if url
         url_config = URLConfig.new(url)
         kwargs = {
           ssl: url_config.ssl?,
-          db: url_config.db,
         }.compact.merge(kwargs)
+        db ||= url_config.db
         host ||= url_config.host
         port ||= url_config.port
         path ||= url_config.path
@@ -206,7 +207,7 @@ class RedisClient
         password ||= url_config.password
       end
 
-      super(username: username, password: password, **kwargs)
+      super(username: username, password: password, db: db, **kwargs)
 
       if @path = path
         @host = nil

--- a/test/redis_client/config_test.rb
+++ b/test/redis_client/config_test.rb
@@ -209,6 +209,23 @@ class RedisClient
       assert_equal [%w[HELLO 3 AUTH george hunter2], %w[SELECT 5]], config.connection_prelude
     end
 
+    def test_overriding_nil
+      config = Config.new(
+        url: "redis://p%40ssw0rd@redis-16379.hosted.com:16379/12",
+        username: nil,
+        password: nil,
+        host: nil,
+        port: nil,
+        db: nil,
+      )
+
+      assert_equal "redis-16379.hosted.com", config.host
+      assert_equal 16379, config.port
+      assert_equal "default", config.username
+      assert_equal "p@ssw0rd", config.password
+      assert_equal 12, config.db
+    end
+
     def test_server_url
       assert_equal "redis://localhost:6379", Config.new.server_url
       assert_equal "redis://localhost:6379", Config.new(username: "george", password: "hunter2").server_url


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/252

```ruby
Redis.new(url: "redis://localhost:6379/3", db: nil).db
```

Before: `0`
After: `3`

This is consistent with how other parameters work.