### PR TITLE
Pass retry attempt count through middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,15 +415,15 @@ either globally or on a given configuration instance.
 
 ```ruby
 module MyGlobalRedisInstrumentation
-  def connect(redis_config)
+  def connect(redis_config, retry_attempts)
     MyMonitoringService.instrument("redis.connect") { super }
   end
 
-  def call(command, redis_config)
+  def call(command, redis_config, retry_attempts)
     MyMonitoringService.instrument("redis.query") { super }
   end
 
-  def call_pipelined(commands, redis_config)
+  def call_pipelined(commands, redis_config, retry_attempts)
     MyMonitoringService.instrument("redis.pipeline") { super }
   end
 end
@@ -443,15 +443,15 @@ If middlewares need a client-specific configuration, `Config#custom` can be used
 
 ```ruby
 module MyGlobalRedisInstrumentation
-  def connect(redis_config)
+  def connect(redis_config, retry_attempts)
     MyMonitoringService.instrument("redis.connect", tags: redis_config.custom[:tags]) { super }
   end
 
-  def call(command, redis_config)
+  def call(command, redis_config, retry_attempts)
     MyMonitoringService.instrument("redis.query", tags: redis_config.custom[:tags]) { super }
   end
 
-  def call_pipelined(commands, redis_config)
+  def call_pipelined(commands, redis_config, retry_attempts)
     MyMonitoringService.instrument("redis.pipeline", tags: redis_config.custom[:tags]) { super }
   end
 end

--- a/lib/redis_client/circuit_breaker.rb
+++ b/lib/redis_client/circuit_breaker.rb
@@ -3,15 +3,15 @@
 class RedisClient
   class CircuitBreaker
     module Middleware
-      def connect(config)
+      def connect(config, _retry_attempts = 0)
         config.circuit_breaker.protect { super }
       end
 
-      def call(_command, config)
+      def call(_command, config, _retry_attempts = 0)
         config.circuit_breaker.protect { super }
       end
 
-      def call_pipelined(_commands, config)
+      def call_pipelined(_commands, config, _retry_attempts = 0)
         config.circuit_breaker.protect { super }
       end
     end

--- a/lib/redis_client/middlewares.rb
+++ b/lib/redis_client/middlewares.rb
@@ -8,11 +8,11 @@ class RedisClient
       @client = client
     end
 
-    def connect(_config)
+    def connect(_config, _retry_attempts = 0)
       yield
     end
 
-    def call(command, _config)
+    def call(command, _config, _retry_attempts = 0)
       yield command
     end
     alias_method :call_pipelined, :call


### PR DESCRIPTION
This would allow middlewares to instrument calls and retries with more granularity, as well as determine if raised errors are final or if they will be retried.

- Discussed in https://github.com/redis-rb/redis-client/issues/119 where users saw an increase in errors reported to DataDog that actually resulted in successful calls due to the default of 1 r`econnect_attempts` in redis-rb / sidekiq

- This was specifically adapted from the idea suggested in https://github.com/redis-rb/redis-client/issues/119#issuecomment-1878372908

There would still need to be changes coordinated in https://github.com/DataDog/dd-trace-rb/issues/3820 to close the initial issue (#119) but this is a generic approach that would also benefit anyone writing their own middlewares