### PR TITLE
Add `RedisClient::Error#final?` to segregate retriable errors in middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add `RedisClient::Error#final?` and `#retriable?` to allow middleware to filter out non-final errors.
 - Fix precedence of `db: nil` initialization parameter.
 
   ```ruby

--- a/README.md
+++ b/README.md
@@ -459,6 +459,29 @@ RedisClient.register(MyGlobalRedisInstrumentation)
 
 redis_config = RedisClient.config(custom: { tags: { "environment": Rails.env }})
 ```
+
+### Instrumenting Errors
+
+It is important to note that when `reconnect_attempts` is enabled, all network errors are reported to the middlewares,
+even the ones that will be retried.
+
+In many cases you may want to ignore retriable errors, or report them differently:
+
+```ruby
+module MyGlobalRedisInstrumentation
+  def call(command, redis_config)
+    super
+  rescue RedisClient::Error => error
+    if error.final?
+      # Error won't be retried.
+    else
+      # Error will be retried.
+    end
+    raise
+  end
+end
+```
+
 ### Timeouts
 
 The client allows you to configure connect, read, and write timeouts.

--- a/hiredis-client/lib/redis_client/hiredis_connection.rb
+++ b/hiredis-client/lib/redis_client/hiredis_connection.rb
@@ -100,9 +100,10 @@ class RedisClient
         end
       end
     rescue SystemCallError, IOError => error
-      raise ConnectionError.with_config(error.message, config)
+      raise connection_error(error.message)
     rescue Error => error
       error._set_config(config)
+      error._set_retry_attempt(@retry_attempt)
       raise error
     end
 
@@ -110,9 +111,10 @@ class RedisClient
       _write(command)
       flush
     rescue SystemCallError, IOError => error
-      raise ConnectionError.with_config(error.message, config)
+      raise connection_error(error.message)
     rescue Error => error
       error._set_config(config)
+      error._set_retry_attempt(@retry_attempt)
       raise error
     end
 
@@ -122,9 +124,10 @@ class RedisClient
       end
       flush
     rescue SystemCallError, IOError => error
-      raise ConnectionError.with_config(error.message, config)
+      raise connection_error(error.message)
     rescue Error => error
       error._set_config(config)
+      error._set_retry_attempt(@retry_attempt)
       raise error
     end
 

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -140,6 +140,10 @@ class RedisClient
         @client_implementation.new(self, **kwargs)
       end
 
+      def retriable?(attempt)
+        @reconnect_attempts && @reconnect_attempts[attempt]
+      end
+
       def retry_connecting?(attempt, _error)
         if @reconnect_attempts
           if (pause = @reconnect_attempts[attempt])

--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -75,7 +75,7 @@ class RedisClient
       begin
         @io.write(buffer)
       rescue SystemCallError, IOError, OpenSSL::SSL::SSLError => error
-        raise ConnectionError.with_config(error.message, config)
+        raise connection_error(error.message)
       end
     end
 
@@ -87,7 +87,7 @@ class RedisClient
       begin
         @io.write(buffer)
       rescue SystemCallError, IOError, OpenSSL::SSL::SSLError => error
-        raise ConnectionError.with_config(error.message, config)
+        raise connection_error(error.message)
       end
     end
 
@@ -100,7 +100,7 @@ class RedisClient
     rescue RedisClient::RESP3::UnknownType => error
       raise RedisClient::ProtocolError.with_config(error.message, config)
     rescue SystemCallError, IOError, OpenSSL::SSL::SSLError => error
-      raise ConnectionError.with_config(error.message, config)
+      raise connection_error(error.message)
     end
 
     def measure_round_trip_delay

--- a/test/support/client_test_helper.rb
+++ b/test/support/client_test_helper.rb
@@ -21,7 +21,7 @@ module ClientTestHelper
     def read(*)
       @fail_now ||= false
       if @fail_now
-        raise ::RedisClient::ConnectionError, "simulated failure"
+        raise connection_error("simulated failure")
       end
 
       super


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/pull/254
Fix: https://github.com/redis-rb/redis-client/issues/119
Ref: https://github.com/redis-rb/redis-client/issues/119

Middlewares witness all network errors, but currently have no way of knowing whether the error is final or is about to be retried.

In many case, you do want to distinguish the two because a low number of transcient network errors can be expected.