### PR TITLE
Set retry_attempt more consistently for `Error#final?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix a few corner cases where `RedisClient::Error#final?` was innacurate.
 - hiredis-client: Properly reconnect to the new leader after a sentinel failover.
 
 # 0.26.0

--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -92,7 +92,9 @@ class RedisClient
     end
 
     def protocol_error(message)
-      ProtocolError.with_config(message, config)
+      error = ProtocolError.with_config(message, config)
+      error._set_retry_attempt(@retry_attempt)
+      error
     end
 
     def connection_error(message)


### PR DESCRIPTION
- fixes https://github.com/redis-rb/redis-client/issues/258

This sets `retry_attempt` on the connection before connect/reconnect so that error.final? is correct for errors during the connection process

This also sets `retry_attempt` in the ruby connection for various errors raised during read/write, similar to what is implemented in the hiredis connection