### PR TITLE
Hiredis+sentinel don't re-use connections after a failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- hiredis-client: Properly reconnect to the new leader after a sentinel failover.
+
 # 0.26.0
 
 - Add `RedisClient::Error#final?` and `#retriable?` to allow middleware to filter out non-final errors.

--- a/hiredis-client/lib/redis_client/hiredis_connection.rb
+++ b/hiredis-client/lib/redis_client/hiredis_connection.rb
@@ -39,11 +39,8 @@ class RedisClient
       end
     end
 
-    attr_reader :config
-
     def initialize(config, connect_timeout:, read_timeout:, write_timeout:)
-      super()
-      @config = config
+      super(config)
       self.connect_timeout = connect_timeout
       self.read_timeout = read_timeout
       self.write_timeout = write_timeout
@@ -134,6 +131,7 @@ class RedisClient
     private
 
     def connect
+      @server_key = @config.server_key
       _connect(@config.path, @config.host, @config.port, @config.ssl_context)
     rescue SystemCallError => error
       host = @config.path || "#{@config.host}:#{@config.port}"

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -786,7 +786,7 @@ class RedisClient
   def connect
     @pid = PIDCache.pid
 
-    if @raw_connection
+    if @raw_connection&.revalidate
       @middlewares.connect(config) do
         @raw_connection.reconnect
       end

--- a/lib/redis_client/config.rb
+++ b/lib/redis_client/config.rb
@@ -186,7 +186,7 @@ class RedisClient
 
     include Common
 
-    attr_reader :host, :port, :path
+    attr_reader :host, :port, :path, :server_key
 
     def initialize(
       url: nil,
@@ -220,6 +220,8 @@ class RedisClient
         @host = host || DEFAULT_HOST
         @port = Integer(port || DEFAULT_PORT)
       end
+
+      @server_key = [@path, @host, @port].freeze
     end
   end
 end

--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -3,10 +3,13 @@
 class RedisClient
   module ConnectionMixin
     attr_accessor :retry_attempt
+    attr_reader :config
 
-    def initialize
+    def initialize(config)
       @pending_reads = 0
       @retry_attempt = nil
+      @config = config
+      @server_key = nil
     end
 
     def reconnect
@@ -20,7 +23,7 @@ class RedisClient
     end
 
     def revalidate
-      if @pending_reads > 0
+      if @pending_reads > 0 || @server_key != @config.server_key
         close
         false
       else

--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -40,11 +40,8 @@ class RedisClient
 
     SUPPORTS_RESOLV_TIMEOUT = Socket.method(:tcp).parameters.any? { |p| p.last == :resolv_timeout }
 
-    attr_reader :config
-
     def initialize(config, connect_timeout:, read_timeout:, write_timeout:)
-      super()
-      @config = config
+      super(config)
       @connect_timeout = connect_timeout
       @read_timeout = read_timeout
       @write_timeout = write_timeout
@@ -112,6 +109,7 @@ class RedisClient
     private
 
     def connect
+      @server_key = @config.server_key
       socket = if @config.path
         UNIXSocket.new(@config.path)
       else

--- a/lib/redis_client/sentinel_config.rb
+++ b/lib/redis_client/sentinel_config.rb
@@ -82,6 +82,10 @@ class RedisClient
       end
     end
 
+    def server_key
+      config.server_key
+    end
+
     def host
       config.host
     end

--- a/test/redis_client/connection_test.rb
+++ b/test/redis_client/connection_test.rb
@@ -205,6 +205,15 @@ class RedisClient
       end
     end
 
+    def test_reconnect_config_change
+      assert_equal "PONG", @redis.call("PING")
+      @redis.close
+      @redis.instance_variable_set(:@config, RedisClient.config(**tcp_config, port: 1))
+      assert_raises RedisClient::CannotConnectError do
+        @redis.call("PING")
+      end
+    end
+
     def test_circuit_breaker
       circuit_breaker = CircuitBreaker.new(error_threshold: 3, success_threshold: 2, error_timeout: 1)
       @redis = new_client(circuit_breaker: circuit_breaker)

--- a/test/sentinel/sentinel_test.rb
+++ b/test/sentinel/sentinel_test.rb
@@ -147,9 +147,11 @@ class RedisClient
       stub(@config, :sentinel_client, ->(_config) { sentinel_client_mock }) do
         client = @config.new_client
         assert_equal "PONG", client.call("PING")
+        initial_server_key = @config.server_key
 
         Toxiproxy[Servers::REDIS.name].down do
           assert_equal "PONG", client.call("PING")
+          refute_equal initial_server_key, @config.server_key
         end
       end
     ensure


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/257 (FYI: @Vasfed)

The `hiredis` C library isn't capable of reconnecting to a different server, only to the same server.

For classic client it's not a big deal, but with sentinel, a failover may have happened, hence the host or port may have changed.