### PR TITLE
Fix compatibility with connection_pool 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix compatibility with `connection_pool` version 3+.
+
 # 0.26.1
 
 - Fix a few corner cases where `RedisClient::Error#final?` was innacurate.

--- a/lib/redis_client/pooled.rb
+++ b/lib/redis_client/pooled.rb
@@ -23,7 +23,7 @@ class RedisClient
     end
 
     def with(options = EMPTY_HASH)
-      pool.with(options) do |client|
+      pool.with(**options) do |client|
         client.connect_timeout = connect_timeout
         client.read_timeout = read_timeout
         client.write_timeout = write_timeout


### PR DESCRIPTION
Fix: https://github.com/redis-rb/redis-client/issues/268