### PR TITLE
Handle IO::Timeout being raised by Socket.tcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Handle Ruby 4.0 connection timeout raising an `IO::Timeout` instead of `Errno::ETIMEDOUT`.
 - Entirely close the connection on authentication failures.
 
 # 0.26.2

--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -156,7 +156,7 @@ class RedisClient
         write_timeout: @write_timeout,
       )
       true
-    rescue SystemCallError, OpenSSL::SSL::SSLError, SocketError => error
+    rescue SystemCallError, IOError, OpenSSL::SSL::SSLError, SocketError => error
       socket&.close
       raise CannotConnectError, error.message, error.backtrace
     end


### PR DESCRIPTION
This is a new behavior in Ruby 4.0.

Ref: https://github.com/ruby/ruby/pull/15602