### PR TITLE
Don't close connection when silently ignoring CLIENT SETINFO error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -220,3 +220,6 @@ Style/AccessModifierDeclarations:
 
 Style/RedundantFreeze:
   Enabled: false # Has some false positives
+
+Style/Next:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix connecting to Redis 7.1 and older with `driver_info:`set.
 - Added `RedisClient::Error#next_error` for an easier way to check all errors produced by a pipeline.
 
 # 0.28.0

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -893,15 +893,21 @@ class RedisClient
     connect_error.set_backtrace(error.backtrace)
     raise connect_error
   rescue CommandError => error
-    @raw_connection&.close
-    if error.message.match?(/ERR unknown command ['`]HELLO['`]/)
-      raise UnsupportedServer,
-        "redis-client requires Redis 6+ with HELLO command available (#{config.server_url})"
-    # Ignore CLIENT SETINFO errors (Redis < 7.2 doesn't support it)
-    elsif error.message.match?(/unknown subcommand.*setinfo/i)
-      # Silently ignore - CLIENT SETINFO is not supported on Redis < 7.2
-    else
-      raise
+    while error && error.command[0] == "CLIENT" && error.command[1] == "SETINFO"
+      # CLIENT SETINFO is unsupported on Redis < 7.2. The pipeline drained all responses before raising,
+      # so if that's the only error, the socket is healthy: keep it.
+      error = error.next_error
+    end
+
+    if error
+      @raw_connection&.close
+
+      if error.command&.first == "HELLO" && error.message.match?(/ERR unknown command/)
+        raise UnsupportedServer,
+          "redis-client requires Redis 6+ with HELLO command available (#{config.server_url})", cause: error
+      else
+        raise error, cause: nil
+      end
     end
   end
 end

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -53,11 +53,15 @@ class RedisClientTest < RedisClientTestCase
   def test_older_server
     fake_redis5_driver = Class.new(RedisClient::RubyConnection) do
       def call_pipelined(commands, *, &_)
-        if commands.any? { |c| c == ["HELLO", "3"] }
-          raise RedisClient::CommandError, "ERR unknown command `HELLO`, with args beginning with: `3`"
-        else
-          super
+        commands.each do |command|
+          if command == ["HELLO", "3"]
+            error = RedisClient::CommandError.new("ERR unknown command `HELLO`, with args beginning with: `3`")
+            error._set_command(command)
+            raise error
+          end
         end
+
+        super
       end
     end
     client = new_client(driver: fake_redis5_driver)
@@ -72,11 +76,15 @@ class RedisClientTest < RedisClientTestCase
   def test_redis_6_server_with_missing_hello_command
     fake_redis6_driver = Class.new(RedisClient::RubyConnection) do
       def call_pipelined(commands, *, &_)
-        if commands.any? { |c| c == ["HELLO", "3"] }
-          raise RedisClient::CommandError, "ERR unknown command 'HELLO'"
-        else
-          super
+        commands.each do |command|
+          if command == ["HELLO", "3"]
+            error = RedisClient::CommandError.new("ERR unknown command 'HELLO'")
+            error._set_command(command)
+            raise error
+          end
         end
+
+        super
       end
     end
     client = new_client(driver: fake_redis6_driver)
@@ -86,6 +94,27 @@ class RedisClientTest < RedisClientTestCase
     end
     assert_includes error.message, "redis-client requires Redis 6+ with HELLO command available"
     assert_includes error.message, "(redis://"
+  end
+
+  def test_driver_info_on_server_without_setinfo
+    fake_redis71_driver = Class.new(RedisClient::RubyConnection) do
+      def call_pipelined(commands, *, &_)
+        commands.each do |command|
+          if command[0] == "CLIENT" && command[1] == "SETINFO"
+            error = RedisClient::CommandError.new("ERR Unknown subcommand or wrong number of arguments for 'SETINFO'")
+            error._set_command(command)
+            raise error
+          end
+        end
+
+        super
+      end
+    end
+
+    client = new_client(driver: fake_redis71_driver, driver_info: "test_v1.0")
+
+    assert_equal "PONG", client.call("PING")
+    assert_predicate client, :connected?
   end
 
   def test_handle_async_raise


### PR DESCRIPTION
## Problem

When a client is configured with `driver_info` and connects to Redis 7.0/7.1, the connection fails on the first command after connect with:

```
IOError: closed stream
  lib/redis_client/ruby_connection/buffered_io.rb:130
```

Reproduction (against Redis 7.0.x):

```ruby
client = RedisClient.new(driver_info: "myapp_v1.0")
client.call("PING")  # => IOError: closed stream
```

## Root cause

In `RedisClient#connect`, the `CommandError` rescue ran `@raw_connection&.close` unconditionally — including in the SETINFO branch that's supposed to *silently ignore* the error. So the prelude pipeline succeeded in draining all responses, but the socket was torn down anyway, leaving the client in a broken state.

## Fix

Move `@raw_connection&.close` into only the branches that re-raise. The SETINFO branch leaves the socket alone — it's healthy because `call_pipelined` already drained all responses before raising.

## Test

Added `test_driver_info_on_server_without_setinfo` using the same fake-driver pattern as the existing `test_redis_6_server_with_missing_hello_command`.
