### PR TITLE
Add `RedisClient::Error#next_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Added `RedisClient::Error#next_error` for an easier way to check all errors produced by a pipeline.
+
 # 0.28.0
 
 - Added `RedisClient::HashRing` for horizontal sharing (compatible with `Redis::Distributed` from `redis-rb`).

--- a/README.md
+++ b/README.md
@@ -361,7 +361,11 @@ end
 
 #### Exception management
 
-The `exception` flag in the `#pipelined` method of `RedisClient` is a feature that modifies the pipeline execution
+By default, when a pipeline produce multiple command errors, only the first encountered error is raised.
+
+However, the raised exception have a `.next_error` method you can use like a linked list to check all encountered errors.
+
+Alternatively, the `exception` flag in the `#pipelined` method of `RedisClient` is a feature that modifies the pipeline execution
 behavior. When set to `false`, it doesn't raise an exception when a command error occurs. Instead, it allows the
 pipeline to execute all commands, and any failed command will be available in the returned array. (Defaults to `true`)
 

--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -148,10 +148,16 @@ class RedisClient
     include HasConfig
     include Retriable
 
+    attr_reader :next_error
+
     def self.with_config(message, config = nil)
       error = new(message)
       error._set_config(config)
       error
+    end
+
+    def _set_next_error(error) # :nodoc:
+      @next_error = error
     end
   end
 

--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -47,7 +47,7 @@ class RedisClient
     end
 
     def call_pipelined(commands, timeouts, exception: true)
-      first_exception = nil
+      first_error = last_error = nil
 
       size = commands.size
       results = Array.new(commands.size)
@@ -69,14 +69,16 @@ class RedisClient
           result._set_command(commands[index])
           result._set_config(config)
           result._set_retry_attempt(@retry_attempt)
-          first_exception ||= result
+
+          last_error&._set_next_error(result)
+          first_error ||= last_error = result
         end
 
         results[index] = result
       end
 
-      if first_exception && exception
-        raise first_exception
+      if first_error && exception
+        raise first_error
       else
         results
       end

--- a/test/shared/redis_client_tests.rb
+++ b/test/shared/redis_client_tests.rb
@@ -206,6 +206,21 @@ module RedisClientTests
     assert_equal ["OK"] * 10, results
   end
 
+  def test_pipeline_with_multiple_error
+    error = assert_raises(RedisClient::CommandError) do
+      @redis.pipelined do |pipeline|
+        pipeline.call("DOESNT-EXIST-1")
+        pipeline.call("DOESNT-EXIST-2")
+      end
+    end
+    assert_equal ["DOESNT-EXIST-1"], error.command
+    assert_instance_of RedisClient::CommandError, error.next_error
+
+    error = error.next_error
+    assert_equal ["DOESNT-EXIST-2"], error.command
+    assert_nil error.next_error
+  end
+
   def test_get_set
     string = "a" * 15_000
     assert_equal "OK", @redis.call("SET", "foo", string)


### PR DESCRIPTION
Makes it easier to check all errors of a pipeline.