### PR TITLE
Sentinel: don't skip checking role if `CLIENT SETINFO` failed

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -869,18 +869,25 @@ class RedisClient
       prelude << ["CLIENT", "SETNAME", id]
     end
 
-    # The connection prelude is deliberately not sent to Middlewares
     if config.sentinel?
       prelude << ["ROLE"]
-      role, = @middlewares.call_pipelined(prelude, config) do
-        @raw_connection.call_pipelined(prelude, nil).last
+    end
+
+    unless prelude.empty?
+      results = @middlewares.call_pipelined(prelude, config) do
+        @raw_connection.call_pipelined(prelude, nil, exception: false)
       end
-      config.check_role!(role)
-    else
-      unless prelude.empty?
-        @middlewares.call_pipelined(prelude, config) do
-          @raw_connection.call_pipelined(prelude, nil)
+
+      results.each do |result|
+        # CLIENT SETINFO is unsupported on Redis < 7.2. The pipeline drained all responses before raising,
+        # so if that's the only error, the socket is healthy: keep it.
+        if result.is_a?(CommandError) && !(result.command[0] == "CLIENT" && result.command[1] == "SETINFO")
+          raise result
         end
+      end
+
+      if config.sentinel?
+        config.check_role!(results.last.first)
       end
     end
   rescue FailoverError, CannotConnectError => error
@@ -893,21 +900,13 @@ class RedisClient
     connect_error.set_backtrace(error.backtrace)
     raise connect_error
   rescue CommandError => error
-    while error && error.command[0] == "CLIENT" && error.command[1] == "SETINFO"
-      # CLIENT SETINFO is unsupported on Redis < 7.2. The pipeline drained all responses before raising,
-      # so if that's the only error, the socket is healthy: keep it.
-      error = error.next_error
-    end
+    @raw_connection&.close
 
-    if error
-      @raw_connection&.close
-
-      if error.command&.first == "HELLO" && error.message.match?(/ERR unknown command/)
-        raise UnsupportedServer,
-          "redis-client requires Redis 6+ with HELLO command available (#{config.server_url})", cause: error
-      else
-        raise error, cause: nil
-      end
+    if error.command&.first == "HELLO" && error.message.match?(/ERR unknown command/)
+      raise UnsupportedServer,
+        "redis-client requires Redis 6+ with HELLO command available (#{config.server_url})", cause: error
+    else
+      raise
     end
   end
 end

--- a/lib/redis_client/sentinel_config.rb
+++ b/lib/redis_client/sentinel_config.rb
@@ -116,6 +116,10 @@ class RedisClient
     end
 
     def check_role!(role)
+      unless role.is_a?(String)
+        raise TypeError, "Expected role to be a string, got: #{role.inspect}"
+      end
+
       if @role == :master
         unless role == "master"
           sleep SENTINEL_DELAY

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -52,16 +52,20 @@ class RedisClientTest < RedisClientTestCase
 
   def test_older_server
     fake_redis5_driver = Class.new(RedisClient::RubyConnection) do
-      def call_pipelined(commands, *, &_)
-        commands.each do |command|
+      def call_pipelined(commands, *, exception:, &_)
+        raise "Expected `exception: false`" if exception
+
+        results = super
+
+        commands.each_with_index do |command, index|
           if command == ["HELLO", "3"]
             error = RedisClient::CommandError.new("ERR unknown command `HELLO`, with args beginning with: `3`")
             error._set_command(command)
-            raise error
+            results[index] = error
           end
         end
 
-        super
+        results
       end
     end
     client = new_client(driver: fake_redis5_driver)
@@ -75,16 +79,20 @@ class RedisClientTest < RedisClientTestCase
 
   def test_redis_6_server_with_missing_hello_command
     fake_redis6_driver = Class.new(RedisClient::RubyConnection) do
-      def call_pipelined(commands, *, &_)
-        commands.each do |command|
+      def call_pipelined(commands, *, exception:, &_)
+        raise "Expected `exception: false`" if exception
+
+        results = super
+
+        commands.each_with_index do |command, index|
           if command == ["HELLO", "3"]
             error = RedisClient::CommandError.new("ERR unknown command 'HELLO'")
             error._set_command(command)
-            raise error
+            results[index] = error
           end
         end
 
-        super
+        results
       end
     end
     client = new_client(driver: fake_redis6_driver)
@@ -98,16 +106,20 @@ class RedisClientTest < RedisClientTestCase
 
   def test_driver_info_on_server_without_setinfo
     fake_redis71_driver = Class.new(RedisClient::RubyConnection) do
-      def call_pipelined(commands, *, &_)
-        commands.each do |command|
+      def call_pipelined(commands, *, exception:, &_)
+        raise "Expected `exception: false`" if exception
+
+        results = super
+
+        commands.each_with_index do |command, index|
           if command[0] == "CLIENT" && command[1] == "SETINFO"
             error = RedisClient::CommandError.new("ERR Unknown subcommand or wrong number of arguments for 'SETINFO'")
             error._set_command(command)
-            raise error
+            results[index] = error
           end
         end
 
-        super
+        results
       end
     end
 


### PR DESCRIPTION
Followup: https://github.com/redis-rb/redis-client/pull/297