### PR TITLE
hiredis-client: add verify_mode support to SSLContext

### DIFF
--- a/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
+++ b/hiredis-client/ext/redis_client/hiredis/hiredis_connection.c
@@ -109,18 +109,20 @@ static VALUE hiredis_ssl_context_alloc(VALUE klass) {
     return TypedData_Make_Struct(klass, hiredis_ssl_context_t, &hiredis_ssl_context_data_type, ssl_context);
 }
 
-static VALUE hiredis_ssl_context_init(VALUE self, VALUE ca_file, VALUE ca_path, VALUE cert, VALUE key, VALUE hostname) {
+static VALUE hiredis_ssl_context_init(VALUE self, VALUE ca_file, VALUE ca_path, VALUE cert, VALUE key, VALUE hostname, VALUE verify_mode) {
     redisSSLContextError ssl_error = 0;
     SSL_CONTEXT(self, ssl_context);
 
-    ssl_context->context = redisCreateSSLContext(
-        RTEST(ca_file) ? StringValueCStr(ca_file) : NULL,
-        RTEST(ca_path) ? StringValueCStr(ca_path) : NULL,
-        RTEST(cert) ? StringValueCStr(cert) : NULL,
-        RTEST(key) ? StringValueCStr(key) : NULL,
-        RTEST(hostname) ? StringValueCStr(hostname) : NULL,
-        &ssl_error
-    );
+    redisSSLOptions options = {
+        .cacert_filename = RTEST(ca_file) ? StringValueCStr(ca_file) : NULL,
+        .capath = RTEST(ca_path) ? StringValueCStr(ca_path) : NULL,
+        .cert_filename = RTEST(cert) ? StringValueCStr(cert) : NULL,
+        .private_key_filename = RTEST(key) ? StringValueCStr(key) : NULL,
+        .server_name = RTEST(hostname) ? StringValueCStr(hostname) : NULL,
+        .verify_mode = NIL_P(verify_mode) ? SSL_VERIFY_PEER : NUM2INT(verify_mode),
+    };
+
+    ssl_context->context = redisCreateSSLContextWithOptions(&options, &ssl_error);
 
     if (ssl_error) {
         return rb_str_new_cstr(redisSSLContextGetError(ssl_error));
@@ -945,5 +947,5 @@ RUBY_FUNC_EXPORTED void Init_hiredis_connection(void) {
 
     VALUE rb_cHiredisSSLContext = rb_define_class_under(rb_cHiredisConnection, "SSLContext", rb_cObject);
     rb_define_alloc_func(rb_cHiredisSSLContext, hiredis_ssl_context_alloc);
-    rb_define_private_method(rb_cHiredisSSLContext, "init", hiredis_ssl_context_init, 5);
+    rb_define_private_method(rb_cHiredisSSLContext, "init", hiredis_ssl_context_init, 6);
 }

--- a/hiredis-client/ext/redis_client/hiredis/vendor/hiredis_ssl.h
+++ b/hiredis-client/ext/redis_client/hiredis/vendor/hiredis_ssl.h
@@ -84,6 +84,16 @@ typedef enum {
     REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED       /* Failed to load private key */
 } redisSSLContextError;
 
+/* Options struct for redisCreateSSLContextWithOptions(). */
+typedef struct {
+    const char *cacert_filename;
+    const char *capath;
+    const char *cert_filename;
+    const char *private_key_filename;
+    const char *server_name;
+    int verify_mode;
+} redisSSLOptions;
+
 /**
  * Return the error message corresponding with the specified error code.
  */
@@ -123,6 +133,12 @@ int redisInitOpenSSL(void);
 redisSSLContext *redisCreateSSLContext(const char *cacert_filename, const char *capath,
         const char *cert_filename, const char *private_key_filename,
         const char *server_name, redisSSLContextError *error);
+
+/**
+ * Variant of redisCreateSSLContext() that accepts a redisSSLOptions struct,
+ * allowing the caller to set verify_mode (e.g. SSL_VERIFY_NONE).
+ */
+redisSSLContext *redisCreateSSLContextWithOptions(redisSSLOptions *options, redisSSLContextError *error);
 
 /**
  * Free a previously created OpenSSL context.

--- a/hiredis-client/ext/redis_client/hiredis/vendor/ssl.c
+++ b/hiredis-client/ext/redis_client/hiredis/vendor/ssl.c
@@ -203,9 +203,7 @@ void redisFreeSSLContext(redisSSLContext *ctx)
  * redisSSLContext helper context initialization.
  */
 
-redisSSLContext *redisCreateSSLContext(const char *cacert_filename, const char *capath,
-        const char *cert_filename, const char *private_key_filename,
-        const char *server_name, redisSSLContextError *error)
+redisSSLContext *redisCreateSSLContextWithOptions(redisSSLOptions *options, redisSSLContextError *error)
 {
     redisSSLContext *ctx = hi_calloc(1, sizeof(redisSSLContext));
     if (ctx == NULL)
@@ -218,40 +216,55 @@ redisSSLContext *redisCreateSSLContext(const char *cacert_filename, const char *
     }
 
     SSL_CTX_set_options(ctx->ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
-    SSL_CTX_set_verify(ctx->ssl_ctx, SSL_VERIFY_PEER, NULL);
+    SSL_CTX_set_verify(ctx->ssl_ctx, options->verify_mode, NULL);
 
-    if ((cert_filename != NULL && private_key_filename == NULL) ||
-            (private_key_filename != NULL && cert_filename == NULL)) {
+    if ((options->cert_filename != NULL && options->private_key_filename == NULL) ||
+            (options->private_key_filename != NULL && options->cert_filename == NULL)) {
         if (error) *error = REDIS_SSL_CTX_CERT_KEY_REQUIRED;
         goto error;
     }
 
-    if (capath || cacert_filename) {
-        if (!SSL_CTX_load_verify_locations(ctx->ssl_ctx, cacert_filename, capath)) {
+    if (options->capath || options->cacert_filename) {
+        if (!SSL_CTX_load_verify_locations(ctx->ssl_ctx, options->cacert_filename, options->capath)) {
             if (error) *error = REDIS_SSL_CTX_CA_CERT_LOAD_FAILED;
             goto error;
         }
     }
 
-    if (cert_filename) {
-        if (!SSL_CTX_use_certificate_chain_file(ctx->ssl_ctx, cert_filename)) {
+    if (options->cert_filename) {
+        if (!SSL_CTX_use_certificate_chain_file(ctx->ssl_ctx, options->cert_filename)) {
             if (error) *error = REDIS_SSL_CTX_CLIENT_CERT_LOAD_FAILED;
             goto error;
         }
-        if (!SSL_CTX_use_PrivateKey_file(ctx->ssl_ctx, private_key_filename, SSL_FILETYPE_PEM)) {
+        if (!SSL_CTX_use_PrivateKey_file(ctx->ssl_ctx, options->private_key_filename, SSL_FILETYPE_PEM)) {
             if (error) *error = REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED;
             goto error;
         }
     }
 
-    if (server_name)
-        ctx->server_name = hi_strdup(server_name);
+    if (options->server_name)
+        ctx->server_name = hi_strdup(options->server_name);
 
     return ctx;
 
 error:
     redisFreeSSLContext(ctx);
     return NULL;
+}
+
+redisSSLContext *redisCreateSSLContext(const char *cacert_filename, const char *capath,
+        const char *cert_filename, const char *private_key_filename,
+        const char *server_name, redisSSLContextError *error)
+{
+    redisSSLOptions options = {
+        .cacert_filename = cacert_filename,
+        .capath = capath,
+        .cert_filename = cert_filename,
+        .private_key_filename = private_key_filename,
+        .server_name = server_name,
+        .verify_mode = SSL_VERIFY_PEER,
+    };
+    return redisCreateSSLContextWithOptions(&options, error);
 }
 
 int redisInitiateSSLContinue(redisContext *c) {

--- a/hiredis-client/lib/redis_client/hiredis_connection.rb
+++ b/hiredis-client/lib/redis_client/hiredis_connection.rb
@@ -10,7 +10,7 @@ class RedisClient
 
     class << self
       def ssl_context(ssl_params)
-        unless ssl_params[:ca_file] || ssl_params[:ca_path]
+        unless ssl_params[:ca_file] || ssl_params[:ca_path] || ssl_params[:verify_mode] == OpenSSL::SSL::VERIFY_NONE
           default_ca_file = OpenSSL::X509::DEFAULT_CERT_FILE
           default_ca_path = OpenSSL::X509::DEFAULT_CERT_DIR
 
@@ -27,13 +27,14 @@ class RedisClient
           cert: ssl_params[:cert],
           key: ssl_params[:key],
           hostname: ssl_params[:hostname],
+          verify_mode: ssl_params[:verify_mode],
         )
       end
     end
 
     class SSLContext
-      def initialize(ca_file: nil, ca_path: nil, cert: nil, key: nil, hostname: nil)
-        if (error = init(ca_file, ca_path, cert, key, hostname))
+      def initialize(ca_file: nil, ca_path: nil, cert: nil, key: nil, hostname: nil, verify_mode: nil)
+        if (error = init(ca_file, ca_path, cert, key, hostname, verify_mode))
           raise error
         end
       end


### PR DESCRIPTION
## Summary

Adds a `verify_mode` key to `ssl_params` so callers can disable SSL peer
certificate verification — needed when connecting to Redis over TLS with
internally-issued CA certificates that OpenSSL's default trust store won't
recognize.

```ruby
RedisClient.new(
  host: "redis.internal",
  port: 6380,
  ssl: true,
  ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
)
```

Problem

The vendored hiredis (v1.0.2) hardcodes SSL_VERIFY_PEER in
redisCreateSSLContext() with no way to override it. A redisCreateSSLContextWithOptions()
API was added to hiredis proper in redis/hiredis#1085 (merged, released in
hiredis 1.1) specifically to address this, but the vendored copy predates it and
hiredis-client has no Ruby-facing verify_mode option regardless.

Related upstream discussions:
- redis/hiredis#1085 — "Make it possible to set SSL verify mode" (the C-level fix this backports)
- redis/hiredis-rb#58 — "hiredis now supports SSL" (open issue tracking missing SSL support in hiredis-rb)
- redis/hiredis-rb#87 — closed PR that attempted SSL support but never wired verify_mode

Changes

- vendor/hiredis_ssl.h — backports REDIS_SSL_VERIFY_NONE/REDIS_SSL_VERIFY_PEER
constants, redisSSLOptions struct, and redisCreateSSLContextWithOptions() declaration
from hiredis 1.1 into the vendored 1.0.2 copy
- vendor/ssl.c — implements redisCreateSSLContextWithOptions(); refactors
redisCreateSSLContext() as a thin wrapper that defaults to REDIS_SSL_VERIFY_PEER
(no behavior change for existing callers)
- hiredis_connection.c — hiredis_ssl_context_init accepts a verify_mode
parameter and calls redisCreateSSLContextWithOptions() instead of the wrapper
- hiredis_connection.rb — threads verify_mode from ssl_params through
SSLContext.new down to the C init call; skips system CA lookup when
VERIFY_NONE is set

Test plan

- [ ] Existing SSL tests pass unchanged (default VERIFY_PEER behavior untouched)
- [ ] Connect to a Redis instance using a self-signed / internal CA cert with
ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } — connection succeeds
- [ ] Same connection without verify_mode — fails with cert error (verifying default is preserved)