### PR TITLE
Delete Gemfile.lock on ruby-head builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
+      - name: Delete Gemfile.lock
+        if: ${{ matrix.ruby == 'ruby-head' }}
+        run: rm -f Gemfile.lock
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
ruby-head removed a constant that breaks about all old versions of bundler, but at the same time, bundler 4.x requires Ruby 3.2+, so to keep testing older ruby versions we have little choices but to regenerate the Gemfile.lock, at least in some cases.