### PR TITLE
Recheck circuit state inside the recovery lock

### DIFF
--- a/lib/redis_client/circuit_breaker.rb
+++ b/lib/redis_client/circuit_breaker.rb
@@ -65,6 +65,8 @@ class RedisClient
     def refresh_state
       now = RedisClient.now
       @lock.synchronize do
+        return unless @state == :open
+
         if @errors.last < (now - @error_timeout)
           if @success_threshold > 0
             @state = :half_open


### PR DESCRIPTION
## Summary
- Recheck whether the circuit is still open after acquiring its recovery mutex.
- Prevent a second waiting caller from reading an empty error history after the first caller closes the circuit.

## Reproduction
On 0.30.1/master, create a breaker with `error_threshold: 1, error_timeout: 0` and trigger one `RedisClient::ConnectionError`. Hold its `@lock`, start two threads calling `breaker.protect { :success }`, wait until both threads block on that mutex, then release it and join both with a deadline.

Before: one succeeds; the other raises `NoMethodError` on `@errors.last < ...`.
After: both return `:success`.

Both callers observe the open state before waiting. The first clears the errors when closing; the second must check state again under the lock. This is separate from the already-merged error-window correction in #247.

## Verification
- Ruby 4.0.6, redis-client 0.30.1; temporary deterministic two-thread reproduction with bounded joins.
- Existing circuit-breaker and pooled suites: 65 cases / 1,210 assertions, zero failures, errors, retries or skips on both baseline and patch.
- Ruby syntax and whitespace checks pass.
- Targeted current RuboCop passes excluding the pre-existing `Style/EmptyClassDefinition` offense on `OpenCircuitError`. No lint configuration changed.

## Compatibility and limitations
No intended breaking changes, API changes, dependency changes or altered threshold policy. Other Ruby implementations and upstream CI are not yet locally verified. No test files added or modified, per the originating project's policy; the focused reproduction was run outside the repository.

Prepared with Codex assistance; findings and checks above were reproduced locally.
