### PR TITLE
Retain every error in a pipeline’s next_error chain

### DIFF
--- a/lib/redis_client/connection_mixin.rb
+++ b/lib/redis_client/connection_mixin.rb
@@ -71,7 +71,8 @@ class RedisClient
           result._set_retry_attempt(@retry_attempt)
 
           last_error&._set_next_error(result)
-          first_error ||= last_error = result
+          first_error ||= result
+          last_error = result
         end
 
         results[index] = result


### PR DESCRIPTION
## Summary
- Advance `last_error` for every failed pipeline command, independently of the initial-error assignment.
- Preserve intermediate errors in the documented `next_error` chain.

## Reproduction
Against a disposable local Redis, pipeline four nonexistent commands named `audit-unknown-one` through `audit-unknown-four`. Rescue the first `RedisClient::CommandError` and follow `next_error`, recording each error's command.

Before: only `one` and `four` are reachable.
After: `one`, `two`, `three`, `four` are reachable in order; the last error's successor is nil. A subsequent `PING` succeeds.

In #298's implementation, `first_error ||= last_error = result` stops assigning `last_error` once the first error exists. Each later error overwrites the first error's successor.

## Verification
- Ruby 4.0.6 / redis-client 0.30.1.
- Four-error before/after reproduction against disposable Redis 8.10.1 over a private Unix socket; verified connection remains drained and usable.
- Existing full Ruby-driver suite against disposable Redis 7.0: baseline 416 cases / 35,464 assertions; patch 416 / 47,591; zero failures, errors, retries or skips. Timing-based assertion loops make assertion totals variable.
- Ruby syntax and whitespace checks pass.
- Targeted current RuboCop passes excluding the pre-existing `Naming/PredicateMethod` offense on `revalidate`; no lint configuration changed.

## Compatibility and limitations
No intended breaking changes or changes to raised-first-error / `exception: false` behavior. The documented chain now includes previously lost errors. Other Ruby implementations, the native driver and upstream CI are not yet locally verified for this individual patch. No test files added or modified, per the originating project's policy; the reproduction was run outside the repository.

Prepared with Codex assistance; findings and checks above were reproduced locally.
