### PR TITLE
Close the underlying socket after a failed TLS handshake

### DIFF
--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -157,8 +157,9 @@ class RedisClient
       )
       true
     rescue SystemCallError, IOError, OpenSSL::SSL::SSLError, SocketError => error
-      socket&.close
       raise CannotConnectError, error.message, error.backtrace
+    ensure
+      socket&.to_io&.close unless @io
     end
 
     KEEP_ALIVE_INTERVAL = 15 # Same as hiredis defaults


### PR DESCRIPTION
## Summary
- Close the underlying IO whenever connection setup exits before BufferedIO takes ownership.
- Cover TLS protocol errors and explicit handshake timeouts without relying on garbage collection.

## Reproduction and cause
Use a local TCPServer bound to 127.0.0.1 on an ephemeral port. In one case, accepted peers write a short non-TLS response; in the other, peers accept but send nothing. Make five TLS client connection attempts with a 20ms connect timeout and no retries.

A temporary Socket.tcp wrapper retains the returned IO objects so their `closed?` state can be inspected without garbage collection masking cleanup. Close all captured sockets and peers during reproduction cleanup.

Before: five failed connections leave all five underlying client IO objects open in each scenario.
After: all five IOs are closed immediately in both scenarios. The calls still raise RedisClient::CannotConnectError.

The existing rescue from #148 closes the SSL wrapper, whose default `sync_close` is false; that does not close its underlying socket. The explicit CannotConnectError raised on handshake timeout also bypasses that rescue. An ensure closes `to_io` unless `@io` took ownership.

This is delayed cleanup until GC, not a claim that Ruby can never reclaim these sockets. Normal successful TLS close already works through BufferedIO and is unchanged.

## Verification
- Ruby 4.0.6; actual loopback sockets and OpenSSL, not a mock TLS implementation.
- Both five-attempt before/after reproductions pass.
- Existing full Ruby-driver suite, including SSL cases, against disposable Redis 7.0: baseline 416 cases / 35,464 assertions; patch 416 / 43,152; zero failures, errors, retries or skips. Timing-based assertion loops make assertion totals variable.
- Targeted RuboCop, Ruby syntax and whitespace checks pass.

## Compatibility and limitations
No intended breaking changes, signature changes, new dependencies or verification-policy changes. The reproduction disables certificate verification solely for its local deliberately invalid endpoint; library defaults remain unchanged. Native-driver behavior is untouched. Other Ruby/OpenSSL/platform combinations and upstream CI are not yet verified locally. No test files added or modified, per the originating project's policy; focused reproductions ran outside the repository.

Prepared with Codex assistance; findings and checks above were reproduced locally.
