### PR TITLE
Decode URI credentials without form semantics

### DIFF
--- a/lib/redis_client/url_config.rb
+++ b/lib/redis_client/url_config.rb
@@ -42,14 +42,14 @@ class RedisClient
     end
 
     def username
-      uri.user if uri.password && !uri.user.empty?
+      URI::RFC2396_PARSER.unescape(uri.user) if uri.password && !uri.user.empty?
     end
 
     def password
       if uri.user && !uri.password
-        URI.decode_www_form_component(uri.user)
+        URI::RFC2396_PARSER.unescape(uri.user)
       elsif uri.user && uri.password
-        URI.decode_www_form_component(uri.password)
+        URI::RFC2396_PARSER.unescape(uri.password)
       end
     end
 


### PR DESCRIPTION
Percent-decode Redis URI usernames as well as passwords while preserving literal plus characters because URI userinfo is not form-encoded.

Verification: focused URL suite 29 cases / 129 assertions; disposable Redis auth reproduction reaches PONG with decoded username and a literal-plus password; Ruby 4.0.6 syntax, RuboCop, and gem build pass. Source-only patch; no tests included.