### PR TITLE
Reject malformed RESP framing consistently

### DIFF
--- a/lib/redis_client/ruby_connection/buffered_io.rb
+++ b/lib/redis_client/ruby_connection/buffered_io.rb
@@ -35,7 +35,13 @@ class RedisClient
         end
 
         def read_chomp(bytes)
+          raise ArgumentError, "negative byte length: #{bytes}" if bytes < 0
+
           ensure_remaining(bytes + EOL_SIZE)
+          unless @buffer.byteslice(@offset + bytes, EOL_SIZE) == EOL
+            raise ArgumentError, "expected CRLF after #{bytes} bytes"
+          end
+
           str = @buffer.byteslice(@offset, bytes)
           @offset += bytes + EOL_SIZE
           str
@@ -72,7 +78,13 @@ class RedisClient
         end
 
         def read_chomp(bytes)
+          raise ArgumentError, "negative byte length: #{bytes}" if bytes < 0
+
           ensure_remaining(bytes + EOL_SIZE)
+          unless @buffer.byteslice(@offset + bytes, EOL_SIZE) == EOL
+            raise ArgumentError, "expected CRLF after #{bytes} bytes"
+          end
+
           str = @buffer.byteslice(@offset, bytes)
           @offset += bytes + EOL_SIZE
           str.force_encoding(Encoding::UTF_8)
@@ -159,15 +171,30 @@ class RedisClient
       def gets_integer
         int = 0
         offset = @offset
+        negative = false
+        digits = false
         while true
           chr = @buffer.getbyte(offset)
 
           if chr
             if chr == 13 # "\r".ord
+              unless @buffer.getbyte(offset + 1)
+                ensure_line
+                return gets_integer
+              end
+              unless @buffer.getbyte(offset + 1) == 10 && digits
+                raise ArgumentError, "invalid integer line"
+              end
+
               @offset = offset + 2
-              break
-            else
+              return negative ? -int : int
+            elsif chr == 45 && offset == @offset # "-".ord
+              negative = true
+            elsif chr >= 48 && chr <= 57
+              digits = true
               int = (int * 10) + chr - 48
+            else
+              raise ArgumentError, "invalid byte in integer line: #{chr}"
             end
             offset += 1
           else
@@ -175,8 +202,6 @@ class RedisClient
             return gets_integer
           end
         end
-
-        int
       end
 
       private

--- a/lib/redis_client/ruby_connection/resp3.rb
+++ b/lib/redis_client/ruby_connection/resp3.rb
@@ -164,16 +164,19 @@ class RedisClient
     end
 
     def parse_array(io)
-      parse_sequence(io, io.gets_integer)
+      parse_sequence(io, parse_length(io))
     end
 
     def parse_set(io)
-      parse_sequence(io, io.gets_integer)
+      parse_sequence(io, parse_length(io))
     end
 
     def parse_map(io)
+      size = parse_length(io)
+      raise SyntaxError, "Invalid map length: #{size}" if size < 0
+
       hash = {}
-      io.gets_integer.times do
+      size.times do
         hash[parse(io).freeze] = parse(io)
       end
       hash
@@ -184,7 +187,8 @@ class RedisClient
     end
 
     def parse_sequence(io, size)
-      return if size < 0 # RESP2 nil
+      return if size == -1 # RESP2 nil
+      raise SyntaxError, "Invalid sequence length: #{size}" if size < -1
 
       array = Array.new(size)
       size.times do |index|
@@ -195,6 +199,8 @@ class RedisClient
 
     def parse_integer(io)
       Integer(io.gets_chomp)
+    rescue ArgumentError => error
+      raise SyntaxError, error.message
     end
 
     def parse_double(io)
@@ -208,25 +214,42 @@ class RedisClient
       else
         Float(value)
       end
+    rescue ArgumentError => error
+      raise SyntaxError, error.message
     end
 
     def parse_null(io)
-      io.skip(EOL_SIZE)
+      io.read_chomp(0)
       nil
+    rescue ArgumentError => error
+      raise SyntaxError, error.message
     end
 
     def parse_blob(io)
-      bytesize = io.gets_integer
-      return if bytesize < 0 # RESP2 nil type
+      bytesize = parse_length(io)
+      return if bytesize == -1 # RESP2 nil type
+      raise SyntaxError, "Invalid blob length: #{bytesize}" if bytesize < -1
 
       str = io.read_chomp(bytesize)
       str.force_encoding(Encoding::BINARY) unless str.valid_encoding?
       str
+    rescue ArgumentError => error
+      raise SyntaxError, error.message
     end
 
     def parse_verbatim_string(io)
       blob = parse_blob(io)
+      unless blob && blob.bytesize >= 4 && blob.getbyte(3) == 58 # ":".ord
+        raise SyntaxError, "Invalid verbatim string"
+      end
+
       blob.byteslice(4..-1)
+    end
+
+    def parse_length(io)
+      io.gets_integer
+    rescue ArgumentError => error
+      raise SyntaxError, error.message
     end
   end
 end


### PR DESCRIPTION
Validate integer and length framing, reject invalid negative lengths, require CRLF for fixed-length and null frames, validate verbatim strings, and normalize conversion failures to RESP syntax errors.

Verification: focused RESP suite 24 cases / 61 assertions; nine malformed-frame reproductions now fail consistently; parser benchmark showed no material regression; Ruby 4.0.6 syntax, RuboCop, and gem build pass. Source-only patch; no tests included.