### PR TITLE
Close sockets when option setup fails

### DIFF
--- a/lib/redis_client/ruby_connection.rb
+++ b/lib/redis_client/ruby_connection.rb
@@ -117,7 +117,7 @@ class RedisClient
       socket = if @config.path
         UNIXSocket.new(@config.path)
       else
-        sock = if SUPPORTS_RESOLV_TIMEOUT
+        socket = if SUPPORTS_RESOLV_TIMEOUT
           begin
             Socket.tcp(@config.host, @config.port, connect_timeout: @connect_timeout, resolv_timeout: @connect_timeout)
           rescue Errno::ETIMEDOUT => timeout_error
@@ -128,9 +128,9 @@ class RedisClient
           Socket.tcp(@config.host, @config.port, connect_timeout: @connect_timeout)
         end
         # disables Nagle's Algorithm, prevents multiple round trips with MULTI
-        sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
-        enable_socket_keep_alive(sock)
-        sock
+        socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+        enable_socket_keep_alive(socket)
+        socket
       end
 
       if @config.ssl


### PR DESCRIPTION
Assign the TCP socket to the method-owned variable before configuring options so the existing ensure path closes it if setsockopt or keepalive setup raises.

Verification: a forced keepalive failure retained an open descriptor before and closes it afterward; focused checks, Ruby 4.0.6 syntax, RuboCop, and gem build pass. Source-only patch; no tests included.